### PR TITLE
[dev] Input refactoring: use `getpid` | `pthread_join` on input thread

### DIFF
--- a/include/input.h
+++ b/include/input.h
@@ -10,10 +10,12 @@
 
 extern unsigned char input_map_keydown[keycode_max_value + 1];
 
+extern pthread_t pthread_input_thread;
+
 extern CFMachPortRef mach_port_reference;
 extern CFRunLoopRef input_run_loop_reference;
 
-int input_initialize(signed int);
+int input_initialize();
 
 struct __CGEvent* tap_event(
   struct __CGEventTapProxy*,

--- a/sources/input.c
+++ b/sources/input.c
@@ -13,12 +13,12 @@
 
 unsigned char input_map_keydown[keycode_max_value + 1];
 
+pthread_t pthread_input_thread;
+
 CFMachPortRef mach_port_reference;
 CFRunLoopRef input_run_loop_reference;
 
-int input_initialize(
-  signed int id_process
-) {
+int input_initialize() {
   for (
     unsigned char index_keycode = 0;
     index_keycode <= keycode_max_value;
@@ -32,7 +32,7 @@ int input_initialize(
   CGEventMask mask_event = CGEventMaskBit(kCGEventKeyDown) | CGEventMaskBit(kCGEventKeyUp);
 
   mach_port_reference = CGEventTapCreateForPid(
-    id_process,
+    getpid(),
     kCGHeadInsertEventTap,
     kCGEventTapOptionListenOnly,
     mask_event,
@@ -49,10 +49,8 @@ int input_initialize(
     return 1;
   }
 
-  pthread_t pthread_cleanup;
-
   return pthread_create(
-    &pthread_cleanup,
+    &pthread_input_thread,
     (void*)0,
     input_thread,
     (void*)0
@@ -100,10 +98,15 @@ void* input_thread(void* _) {
 
   CFRunLoopRun();
 
-  return 0;
+  return (void*)0;
 }
 
 void input_destroy() {
   CFRunLoopStop(input_run_loop_reference);
   CFRelease(mach_port_reference);
+
+  pthread_join(
+    pthread_input_thread,
+    (void*)0
+  );
 }

--- a/sources/zoe.m
+++ b/sources/zoe.m
@@ -20,11 +20,7 @@ int main(
   NSApplication* application = [NSApplication sharedApplication];
   application.delegate = [zoe_application_delegate alloc];
   
-  int status_input_initialization = (
-    input_initialize(
-      [[NSRunningApplication currentApplication] processIdentifier]
-    )
-  );
+  int status_input_initialization = input_initialize();
 
   if (status_input_initialization != 0) {
     return status_input_initialization;


### PR DESCRIPTION
- `input`:
- - use `getpid`
- - `pthread_join` on input thread