### PR TITLE
[dev|enh] refactor_input_to_use_window_events

### DIFF
--- a/include/application/zoe_window.h
+++ b/include/application/zoe_window.h
@@ -4,6 +4,11 @@
 #import <AppKit/AppKit.h>
 
 @interface zoe_window: NSWindow
+
+- (void) keyDown:(NSEvent *) event;
+- (void) keyUp:(NSEvent *) event;
+- (BOOL) canBecomeKeyWindow;
+
 @end
 
 #endif

--- a/include/input.h
+++ b/include/input.h
@@ -3,29 +3,8 @@
 
 #include <keycodes.h>
 
-#include <pthread.h>
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <CoreGraphics/CoreGraphics.h>
-
 extern unsigned char input_map_keydown[keycode_max_value + 1];
 
-extern pthread_t pthread_input_thread;
-
-extern CFMachPortRef mach_port_reference;
-extern CFRunLoopRef input_run_loop_reference;
-
-int input_initialize();
-
-struct __CGEvent* tap_event(
-  struct __CGEventTapProxy*,
-  CGEventType,
-  struct __CGEvent*,
-  void*
-);
-
-void* input_thread(void*);
-
-void input_destroy();
+void input_initialize();
 
 #endif

--- a/sources/application/zoe_application_delegate.m
+++ b/sources/application/zoe_application_delegate.m
@@ -1,13 +1,10 @@
 #include <application/zoe_application_delegate.h>
 
-#include <input.h>
-
 #include <interrupt_handler.h>
 
 @implementation zoe_application_delegate {}
 
 - (void) applicationWillTerminate: (NSNotification*) notification {
-  input_destroy();
   interrupt_handler_destroy();
 }
 

--- a/sources/application/zoe_window.m
+++ b/sources/application/zoe_window.m
@@ -1,4 +1,27 @@
 #include <application/zoe_window.h>
 
+#include <input.h>
+
 @implementation zoe_window {}
+
+- (void) keyDown: (NSEvent*) event {
+  unsigned short int code_key = event.keyCode;
+
+  input_map_keydown[
+    code_key
+  ] = 1;
+}
+
+- (void) keyUp: (NSEvent*) event {
+  unsigned short int code_key = event.keyCode;
+
+  input_map_keydown[
+    code_key
+  ] = 0;
+}
+
+- (BOOL) canBecomeKeyWindow {
+  return 1;
+}
+
 @end

--- a/sources/input.c
+++ b/sources/input.c
@@ -2,23 +2,9 @@
 
 #include <keycodes.h>
 
-#include <interrupt_handler.h>
-
-#include <pthread.h>
-#include <signal.h>
-#include <stdio.h>
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <CoreGraphics/CoreGraphics.h>
-
 unsigned char input_map_keydown[keycode_max_value + 1];
 
-pthread_t pthread_input_thread;
-
-CFMachPortRef mach_port_reference;
-CFRunLoopRef input_run_loop_reference;
-
-int input_initialize() {
+void input_initialize() {
   for (
     unsigned char index_keycode = 0;
     index_keycode <= keycode_max_value;
@@ -28,85 +14,4 @@ int input_initialize() {
       index_keycode
     ] = 0;
   }
-
-  CGEventMask mask_event = CGEventMaskBit(kCGEventKeyDown) | CGEventMaskBit(kCGEventKeyUp);
-
-  mach_port_reference = CGEventTapCreateForPid(
-    getpid(),
-    kCGHeadInsertEventTap,
-    kCGEventTapOptionListenOnly,
-    mask_event,
-    tap_event,
-    stdout
-  );
-
-  if (mach_port_reference == (void*)0) {
-    fprintf(
-      stderr,
-      "failed_to_create_tap\n"
-    );
-
-    return 1;
-  }
-
-  return pthread_create(
-    &pthread_input_thread,
-    (void*)0,
-    input_thread,
-    (void*)0
-  );
-}
-
-struct __CGEvent* tap_event(
-  struct __CGEventTapProxy * proxy_tap_event,
-  CGEventType type_event,
-  struct __CGEvent *event,
-  void* data_user
-) {
-  long long int code_key = CGEventGetIntegerValueField(
-    event,
-    kCGKeyboardEventKeycode
-  );
-
-  if (type_event == kCGEventKeyDown) {
-    input_map_keydown[
-      code_key
-    ] = 1;
-  } else if (type_event == kCGEventKeyUp) {
-    input_map_keydown[
-      code_key
-    ] = 0;
-  }
-
-  return event;
-}
-
-void* input_thread(void* _) {
-  CFRunLoopSourceRef run_loop_source_reference = CFMachPortCreateRunLoopSource(
-    kCFAllocatorDefault,
-    mach_port_reference,
-    0
-  );
-
-  input_run_loop_reference = CFRunLoopGetCurrent();
-
-  CFRunLoopAddSource(
-    input_run_loop_reference,
-    run_loop_source_reference,
-    kCFRunLoopCommonModes
-  );
-
-  CFRunLoopRun();
-
-  return (void*)0;
-}
-
-void input_destroy() {
-  CFRunLoopStop(input_run_loop_reference);
-  CFRelease(mach_port_reference);
-
-  pthread_join(
-    pthread_input_thread,
-    (void*)0
-  );
 }

--- a/sources/zoe.m
+++ b/sources/zoe.m
@@ -1,7 +1,6 @@
 #import <zoe.h>
 
 #include <application/zoe_application_delegate.h>
-#include <input.h>
 
 #include <interrupt_handler.h>
 
@@ -19,12 +18,6 @@ int main(
 
   NSApplication* application = [NSApplication sharedApplication];
   application.delegate = [zoe_application_delegate alloc];
-  
-  int status_input_initialization = input_initialize();
-
-  if (status_input_initialization != 0) {
-    return status_input_initialization;
-  }
 
   interrupt_handler_interrupt_function_add(
     terminate_on_signal


### PR DESCRIPTION
- refactor input to not use event taps or require global input monitoring