### PR TITLE
[dev] `.github/workflows/continuous_integration_build`:add_git_config_default_branch.as(`core`);

### DIFF
--- a/.github/workflows/continuous_integration_build.yml
+++ b/.github/workflows/continuous_integration_build.yml
@@ -8,6 +8,8 @@ jobs:
   continuous_integration_build:
     runs-on: macos-latest
     steps:
+      - name: git_initialization
+        run: git config --global init.defaultBranch core
       - name: continuous_integration:repository->checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
- `.github/workflows/continuous_integration_build`:add->{`git_config_global_default_branch_name`.as(`core`)};