### PR TITLE
[enh] `scenes/scene_menu_main`: eased out rotation animation

### DIFF
--- a/include/scenes/scene.h
+++ b/include/scenes/scene.h
@@ -39,9 +39,11 @@ struct scene {
 
   unsigned long int time;
   unsigned long int time_previous;
+  unsigned long int time_delta;
 
   unsigned long int time_input;
   unsigned long int time_input_previous;
+  unsigned long int time_input_delta;
 
   function_scene_poll poll;
   function_scene_poll_input poll_input;

--- a/include/utilities/time.h
+++ b/include/utilities/time.h
@@ -2,6 +2,7 @@
 #define __utilities_time_h
 
 #define time_seconds_to_microseconds(x) ((x) * 1000000000)
+#define time_seconds_to_milliseconds(x) ((x) * 1000)
 #define time_microseconds_to_milliseconds(x) ((x) / 1000)
 
 unsigned long int time_milliseconds_get();

--- a/metal/zoe_shaders.metal
+++ b/metal/zoe_shaders.metal
@@ -4,7 +4,7 @@
 
 #include <clic3_vector.h>
 
-constant float brightness_maximum = 1.0f;
+constant float brightness_maximum = 0.1f;
 
 struct data_rasterizer {
   float4 position [[position]];

--- a/metal/zoe_shaders.metal
+++ b/metal/zoe_shaders.metal
@@ -70,23 +70,25 @@ vertex data_rasterizer zoe_shader_vertex(
       out.position_texture.x = (
         out.position_texture.x - 1.0f
       );
-      z = z + 1;
+
+      z = z == 0 ? 1 : 0;
     }
 
     while (out.position_texture.y > 1.0f) {
       out.position_texture.y = (
         out.position_texture.y - 1.0f
       );
-      x = x + 1;
+
+      x = x == 0 ? 1 : 0;
     }
 
-    if (z % 2 != 0) {
+    if (z == 1) {
       out.position_texture.x = 1.0f - (
         out.position_texture.x
       );
     }
 
-    if (x % 2 != 0) {
+    if (x == 1) {
       out.position_texture.y = 1.0f - (
         out.position_texture.y
       );

--- a/sources/scenes/scene.m
+++ b/sources/scenes/scene.m
@@ -55,6 +55,10 @@ void scene_poll_input(
 ) {
   scene->time_input_previous = scene->time;
   scene->time_input = time;
+  scene->time_input_delta = scene->time_input_previous == 0 ? 0 : (
+    scene->time_input -
+    scene->time_input_previous
+  );
 
   scene->poll_input(
     scene
@@ -67,6 +71,10 @@ void scene_poll(
 ) {
   scene->time_previous = scene->time;
   scene->time = time;
+  scene->time_delta = scene->time_previous == 0 ? 0 : (
+    scene->time -
+    scene->time_previous
+  );
 
   scene->poll(
     scene

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -196,12 +196,21 @@ void scene_menu_main_initialize(
     -50.0f
   );
 
-  scene->player.rotation.x = -0.666f;
+  scene->player.rotation.x = -0.6f;
 }
 
 void scene_menu_main_poll(
   struct scene* scene
 ) {
+  scene->player.rotation.x = fmax(
+    scene->player.rotation.x - (
+      ((scene->player.rotation.x - -0.666f) / 0.066f) *
+      0.00001f *
+      scene->time_delta
+    ),
+    -0.666f
+  );
+
   struct menu* menu = (struct menu*) scene->data;
 
   menu_print(menu);

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -105,9 +105,9 @@ void scene_menu_main_initialize(
 
   mesh_ground_initialize(
     &scene->objects[0]->mesh,
-    2000.0f,
-    500.0f,
-    2000.0f
+    666.0f,
+    6666.6f,
+    200.0f
   );
 
   scene->objects[0]->position.y = -10.0f;

--- a/sources/utilities/time.c
+++ b/sources/utilities/time.c
@@ -10,7 +10,8 @@ unsigned long int time_milliseconds_get() {
     (void*)0
   );
 
-  return time_microseconds_to_milliseconds(
-    time_seconds_to_microseconds(timeval.tv_sec) + timeval.tv_usec
+  return (
+    time_seconds_to_milliseconds(timeval.tv_sec) +
+    time_microseconds_to_milliseconds(timeval.tv_usec)
   );
 }


### PR DESCRIPTION
- `scenes/scene`:add_time_deltas
- `scenes/scene_menu_main`:
- - add:eased_out_rotation_animation
- - restrict_bounding_area
- `utilities/time`:fix_overflowing_values
- `metal/zoe_shaders`
- - lower_brightness
- - fix_potential_overflow  

<img width="3932" height="2490" alt="t" src="https://github.com/user-attachments/assets/654c556d-2e04-4cf2-bfa6-0c232293d8d5" />
