### PR TITLE
[bug] `scenes/scene_menu_main`:fix_camera_height

### DIFF
--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -316,7 +316,7 @@ void scene_menu_main_initialize(
   ];
 
   scene->player.position.y = (
-    -metil_camera_height_default + 2.0f
+    -metil_camera_height_default + 3.0f
   );
 
   scene->player.position.z = (


### PR DESCRIPTION
- `scenes/scene_menu_main`: prevent camera clipping into ground