### PR TITLE
[dev|enh] use_multiple_render_pipelines | increase movement speed | refactor headers

### DIFF
--- a/include/menus/menu_main.h
+++ b/include/menus/menu_main.h
@@ -1,5 +1,5 @@
-#ifndef __menus_menu_main_h
-#define __menus_menu_main_h
+#ifndef __zoe_menus_menu_main_h
+#define __zoe_menus_menu_main_h
 
 #include <metil_menus/menu.h>
 

--- a/include/mesh/ground/mesh_ground.h
+++ b/include/mesh/ground/mesh_ground.h
@@ -1,5 +1,5 @@
-#ifndef __mesh_ground_h
-#define __mesh_ground_h
+#ifndef __zoe_mesh_ground_mesh_ground_h
+#define __zoe_mesh_ground_mesh_ground_h
 
 #include <clic3_vector.h>
 #include <metil_mesh/mesh.h>

--- a/include/mesh/mesh_player.h
+++ b/include/mesh/mesh_player.h
@@ -1,5 +1,5 @@
-#ifndef __mesh_player_h
-#define __mesh_player_h
+#ifndef __zoe_mesh_mesh_player_h
+#define __zoe_mesh_mesh_player_h
 
 #include <metil_mesh/mesh.h>
 

--- a/include/mesh/mesh_player_mirror.h
+++ b/include/mesh/mesh_player_mirror.h
@@ -1,5 +1,5 @@
-#ifndef __mesh_player_mirror_h
-#define __mesh_player_mirror_h
+#ifndef __zoe_mesh_mesh_player_mirror_h
+#define __zoe_mesh_mesh_player_mirror_h
 
 #include <metil_mesh/mesh.h>
 

--- a/include/mesh/mesh_text.h
+++ b/include/mesh/mesh_text.h
@@ -1,5 +1,5 @@
-#ifndef __mesh_text_h
-#define __mesh_text_h
+#ifndef __zoe_mesh_mesh_text_h
+#define __zoe_mesh_mesh_text_h
 
 #include <metil_mesh/mesh.h>
 

--- a/include/mesh/tree/mesh_tree.h
+++ b/include/mesh/tree/mesh_tree.h
@@ -1,5 +1,5 @@
-#ifndef __mesh_tree_h
-#define __mesh_tree_h
+#ifndef __zoe_mesh_tree_mesh_tree_h
+#define __zoe_mesh_tree_mesh_tree_h
 
 #include <metil_mesh/mesh.h>
 

--- a/include/mode_texture.h
+++ b/include/mode_texture.h
@@ -1,5 +1,5 @@
-#ifndef __metal_kit_shader_types_h
-#define __metal_kit_shader_types_h
+#ifndef __zoe_mode_texture_h
+#define __zoe_mode_texture_h
 
 enum mode_texture {
   mode_texture_default,

--- a/include/scenes/scene_id.h
+++ b/include/scenes/scene_id.h
@@ -1,5 +1,5 @@
-#ifndef __scenes_scene_h
-#define __scenes_scene_h
+#ifndef __zoe_scenes_scene_id_h
+#define __zoe_scenes_scene_id_h
 
 enum scene_id {
   scene_id_unknown,

--- a/include/scenes/scene_intro_forest.h
+++ b/include/scenes/scene_intro_forest.h
@@ -1,5 +1,5 @@
-#ifndef __scenes_scene_intro_forest_h
-#define __scenes_scene_intro_forest_h
+#ifndef __zoe_scenes_scene_intro_forest_h
+#define __zoe_scenes_scene_intro_forest_h
 
 #include <metil.h>
 

--- a/include/scenes/scene_menu_main.h
+++ b/include/scenes/scene_menu_main.h
@@ -1,5 +1,5 @@
-#ifndef __scenes_scene_menu_main_h
-#define __scenes_scene_menu_main_h
+#ifndef __zoe_scenes_scene_menu_main_h
+#define __zoe_scenes_scene_menu_main_h
 
 #include <metil.h>
 

--- a/include/zoe.h
+++ b/include/zoe.h
@@ -1,11 +1,7 @@
 #ifndef __zoe_h
 #define __zoe_h
 
-#include <metil_rendering/rendering_properties.h>
-
-#include <MetalKit/MetalKit.h>
-
-extern id<MTLDevice> _Nullable metal_kit_device;
+#include <metil_rendering/metil_renderer_interface.h>
 
 int main(
   int,
@@ -13,8 +9,7 @@ int main(
 );
 
 void zoe_renderer_on_initialize(
-  _Nonnull id<MTLDevice>,
-  struct metil_rendering_properties* _Nonnull,
+  struct metil_renderer_interface* _Nonnull metil_renderer_interface,
   void* _Nullable
 );
 

--- a/include/zoe_pipeline_index.h
+++ b/include/zoe_pipeline_index.h
@@ -1,0 +1,9 @@
+#ifndef __zoe_pipeline_index_h
+#define __zoe_pipeline_index_h
+
+extern unsigned short int zoe_pipeline_index_ground;
+extern unsigned short int zoe_pipeline_index_player;
+extern unsigned short int zoe_pipeline_index_text;
+extern unsigned short int zoe_pipeline_index_tree;
+
+#endif

--- a/metal/zoe_default.metal
+++ b/metal/zoe_default.metal
@@ -1,0 +1,67 @@
+#include <mode_texture.h>
+
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+#include <metal_stdlib>
+
+struct data_vertex {
+  float4 position [[position]];
+  float2 position_texture;
+  float brightness;
+};
+
+[[vertex]] struct data_vertex zoe_default_vertex(
+  const device simd_float4* positions [[
+    buffer(
+      metil_renderer_vertex_index_parameter_positions
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  data_vertex.position = data_object->view_model_matrix_projection * positions[id_vertex];
+
+  data_vertex.position_texture.x = id_vertex % 2;
+  data_vertex.position_texture.y = id_vertex % 2;
+
+  data_vertex.brightness = data_frame->brightness;
+
+  return data_vertex;
+}
+
+fragment float4 zoe_default_fragment(
+  struct data_vertex data_vertex [[stage_in]],
+  metal::texture2d<half> texture [[ texture(0) ]]
+) {
+  constexpr metal::sampler sampler_texture(
+    metal::filter::linear,
+    metal::mip_filter::linear
+  );
+
+  float4 texture_color = float4(
+    texture.sample(
+      sampler_texture,
+      data_vertex.position_texture
+    )
+  );
+
+  return float4(
+    texture_color[0] * data_vertex.brightness,
+    texture_color[1] * data_vertex.brightness,
+    texture_color[2] * data_vertex.brightness,
+    texture_color[3]
+  );
+}

--- a/metal/zoe_ground.metal
+++ b/metal/zoe_ground.metal
@@ -18,7 +18,7 @@ struct data_vertex {
   float brightness_text;
 };
 
-[[vertex]] struct data_vertex zoe_shader_vertex(
+[[vertex]] struct data_vertex zoe_ground_vertex(
   const device simd_float4* positions [[
     buffer(
       metil_renderer_vertex_index_parameter_positions
@@ -113,52 +113,6 @@ struct data_vertex {
     } else {
       data_vertex.height = (positions[id_vertex].y / data_object->height) * 0.4;
     }
-  } else if (
-    data_object->mode_texture == mode_texture_player
-  ) {
-    data_vertex.index_texture = 0;
-
-    if (id_vertex == 0) {
-      data_vertex.position_texture.x = 0.5f;
-      data_vertex.position_texture.y = metal::fabs(1.0f - (float)(data_frame->frame % 221) / 110.0f);
-    } else {
-      data_vertex.position_texture.x = (float) ((id_vertex - 1)) / 6.0f;
-      
-      if (data_vertex.position_texture.x > 1.0f) {
-        data_vertex.position_texture.x = 1.0f - (data_vertex.position_texture.x - 1.0f);
-      }
-
-      data_vertex.position_texture.y = metal::fabs(((float)(data_frame->frame % 667) / 333.0f) - 1.0f);
-    }
-  } else if (
-    data_object->mode_texture == mode_texture_text
-  ) {
-    data_vertex.index_texture = 0;
-
-    data_vertex.position_texture.x = (
-      id_vertex == 0 || id_vertex == 3
-      ? 0
-      : 1
-    );
-
-    data_vertex.position_texture.y = (
-      id_vertex == 0 || id_vertex == 1
-      ? 1
-      : 0
-    );
-  } else {
-    data_vertex.index_texture = 0;
-    data_vertex.height = positions[id_vertex].y / data_object->height;
-
-    if (positions[id_vertex].x > data_object->width || positions[id_vertex].z > data_object->depth) {
-      data_vertex.height = metal::fmin(positions[id_vertex].y / data_object->height * 0.2f, 0.2f);
-      data_vertex.position_texture.y = id_vertex % 2 == 0 ? 1.0f : 0.0f;
-      data_vertex.position_texture.x = (float)((unsigned short int)(metal::fabs(positions[id_vertex].x + positions[id_vertex].z) * 10000.0f) % 74) / 74.0f;
-    } else {
-      data_vertex.height = metal::fmin(positions[id_vertex].y / data_object->height * 0.8, 0.2f);
-      data_vertex.position_texture.y = id_vertex % 20 < 10 ? 1.0f : 0.0f;
-      data_vertex.position_texture.x = metal::fabs(positions[id_vertex].x + positions[id_vertex].z) / (data_object->width * 2.0f);
-    }
   }
 
   data_vertex.brightness = data_frame->brightness;
@@ -194,7 +148,7 @@ struct data_vertex {
   return data_vertex;
 }
 
-fragment float4 zoe_shader_fragment(
+fragment float4 zoe_ground_fragment(
   struct data_vertex data_vertex [[stage_in]],
   metal::texture2d<half> texture [[ texture(0) ]],
   metal::texture2d<half> texture_two [[ texture(1) ]]
@@ -217,41 +171,15 @@ fragment float4 zoe_shader_fragment(
 
   float brightness = data_vertex.brightness;
 
-  if (
-    data_vertex.mode_texture == mode_texture_text
-  ) {
-    return float4(
-      texture_color[0] * data_vertex.noise * data_vertex.brightness_text,
-      texture_color[1] * data_vertex.noise * data_vertex.brightness_text,
-      texture_color[2] * data_vertex.noise * data_vertex.brightness_text,
-      texture_color[3]
-    );
-  } else if (
-    data_vertex.mode_texture == mode_texture_player
-  ) {
-    return float4(
-      texture_color[0] * brightness * 0.02f,
-      texture_color[1] * brightness * 0.019f,
-      texture_color[2] * brightness * 0.02f,
-      texture_color[3]
-    );
-  } else {
-    if (
-      data_vertex.mode_texture == mode_texture_ground
-    ) {
-      brightness = ((data_vertex.height * 0.8f) + 0.075f) * brightness;
-    } else {
-      brightness = ((data_vertex.height * 0.8f) + 0.075f) * (brightness * 0.8f);
-    }
+  brightness = ((data_vertex.height * 0.8f) + 0.075f) * brightness;
 
-    brightness = brightness * metal::fmax(
-      metal::fmin(
-        100.0f / data_vertex.distance,
-        1.0f
-      ),
-      0.0f
-    );
-  }
+  brightness = brightness * metal::fmax(
+    metal::fmin(
+      100.0f / data_vertex.distance,
+      1.0f
+    ),
+    0.0f
+  );
 
   return float4(
     texture_color[0] * brightness,

--- a/metal/zoe_player.metal
+++ b/metal/zoe_player.metal
@@ -1,0 +1,77 @@
+#include <mode_texture.h>
+
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+#include <metal_stdlib>
+
+struct data_vertex {
+  float4 position [[position]];
+  float2 position_texture;
+  float brightness;
+};
+
+[[vertex]] struct data_vertex zoe_player_vertex(
+  const device simd_float4* positions [[
+    buffer(
+      metil_renderer_vertex_index_parameter_positions
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  data_vertex.position = data_object->view_model_matrix_projection * positions[id_vertex];
+
+  if (id_vertex == 0) {
+    data_vertex.position_texture.x = 0.5f;
+    data_vertex.position_texture.y = metal::fabs(1.0f - (float)(data_frame->frame % 221) / 110.0f);
+  } else {
+    data_vertex.position_texture.x = (float) ((id_vertex - 1)) / 6.0f;
+    
+    if (data_vertex.position_texture.x > 1.0f) {
+      data_vertex.position_texture.x = 1.0f - (data_vertex.position_texture.x - 1.0f);
+    }
+
+    data_vertex.position_texture.y = metal::fabs(((float)(data_frame->frame % 667) / 333.0f) - 1.0f);
+  }
+
+  data_vertex.brightness = data_frame->brightness;
+
+  return data_vertex;
+}
+
+fragment float4 zoe_player_fragment(
+  struct data_vertex data_vertex [[stage_in]],
+  metal::texture2d<half> texture [[ texture(0) ]]
+) {
+  constexpr metal::sampler sampler_texture(
+    metal::filter::linear,
+    metal::mip_filter::linear
+  );
+
+  float4 texture_color = float4(
+    texture.sample(
+      sampler_texture,
+      data_vertex.position_texture
+    )
+  );
+
+  return float4(
+    texture_color[0] * data_vertex.brightness * 0.02f,
+    texture_color[1] * data_vertex.brightness * 0.019f,
+    texture_color[2] * data_vertex.brightness * 0.02f,
+    texture_color[3]
+  );
+}

--- a/metal/zoe_text.metal
+++ b/metal/zoe_text.metal
@@ -1,0 +1,78 @@
+#include <mode_texture.h>
+
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+#include <metal_stdlib>
+
+struct data_vertex {
+  float4 position [[position]];
+  float2 position_texture;
+  float noise;
+  float brightness;
+};
+
+[[vertex]] struct data_vertex zoe_text_vertex(
+  const device simd_float4* positions [[
+    buffer(
+      metil_renderer_vertex_index_parameter_positions
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  data_vertex.position = data_object->view_model_matrix_projection * positions[id_vertex];
+  data_vertex.noise = (float)(data_object->noise % 10001) / 10000.0f;
+
+  data_vertex.position_texture.x = (
+    id_vertex == 0 || id_vertex == 3
+    ? 0
+    : 1
+  );
+
+  data_vertex.position_texture.y = (
+    id_vertex == 0 || id_vertex == 1
+    ? 1
+    : 0
+  );
+
+  data_vertex.brightness = data_frame->brightness_text;
+
+  return data_vertex;
+}
+
+[[fragment]] float4 zoe_text_fragment(
+  struct data_vertex data_vertex [[stage_in]],
+  metal::texture2d<half> texture [[ texture(0) ]]
+) {
+  constexpr metal::sampler sampler_texture(
+    metal::filter::linear,
+    metal::mip_filter::linear
+  );
+
+  float4 texture_color = float4(
+    texture.sample(
+      sampler_texture,
+      data_vertex.position_texture
+    )
+  );
+
+  return float4(
+    texture_color[0] * data_vertex.noise * data_vertex.brightness,
+    texture_color[1] * data_vertex.noise * data_vertex.brightness,
+    texture_color[2] * data_vertex.noise * data_vertex.brightness,
+    texture_color[3]
+  );
+}

--- a/metal/zoe_tree.metal
+++ b/metal/zoe_tree.metal
@@ -1,0 +1,130 @@
+#include <mode_texture.h>
+
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+#include <metal_stdlib>
+
+struct data_vertex {
+  float4 position [[position]];
+  float distance;
+  float height;
+  float2 position_texture;
+  unsigned char mode_texture;
+  unsigned char index_texture;
+  float noise;
+  float brightness;
+  float brightness_text;
+};
+
+[[vertex]] struct data_vertex zoe_tree_vertex(
+  const device simd_float4* positions [[
+    buffer(
+      metil_renderer_vertex_index_parameter_positions
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  data_vertex.position = data_object->view_model_matrix_projection * positions[id_vertex];
+  data_vertex.height = 0.0f;
+  data_vertex.mode_texture = data_object->mode_texture;
+  data_vertex.noise = (float)(data_object->noise % 10001) / 10000.0f;
+
+  data_vertex.index_texture = 0;
+  data_vertex.height = positions[id_vertex].y / data_object->height;
+
+  if (positions[id_vertex].x > data_object->width || positions[id_vertex].z > data_object->depth) {
+    data_vertex.height = metal::fmin(positions[id_vertex].y / data_object->height * 0.2f, 0.2f);
+    data_vertex.position_texture.y = id_vertex % 2 == 0 ? 1.0f : 0.0f;
+    data_vertex.position_texture.x = (float)((unsigned short int)(metal::fabs(positions[id_vertex].x + positions[id_vertex].z) * 10000.0f) % 74) / 74.0f;
+  } else {
+    data_vertex.height = metal::fmin(positions[id_vertex].y / data_object->height * 0.8, 0.2f);
+    data_vertex.position_texture.y = id_vertex % 20 < 10 ? 1.0f : 0.0f;
+    data_vertex.position_texture.x = metal::fabs(positions[id_vertex].x + positions[id_vertex].z) / (data_object->width * 2.0f);
+  }
+
+  data_vertex.brightness = data_frame->brightness;
+  data_vertex.brightness_text = data_frame->brightness_text;
+
+  if (data_object->noise == 666) {
+    data_vertex.distance = (
+      metal::fabs((data_object->position.x + positions[id_vertex].x)) + 
+      metal::fabs((data_object->position.y + positions[id_vertex].y) - 60.0f) + 
+      metal::fabs((data_object->position.z + positions[id_vertex].z))
+    );
+
+    if (
+      (data_object->position.x + positions[id_vertex].x) < 50 &&
+      (data_object->position.x + positions[id_vertex].x) > -50 &&
+      (data_object->position.z + positions[id_vertex].z) < 50 &&
+      (data_object->position.z + positions[id_vertex].z) > -50
+    ) {
+      data_vertex.distance = data_vertex.distance * 5;
+    } else {
+      data_vertex.distance = data_vertex.distance * 7;
+    }
+    
+    data_vertex.height = 1.0f;
+  } else {
+    data_vertex.distance = (
+      metal::fabs((data_object->position.x + positions[id_vertex].x) + data_frame->position_player.x) + 
+      metal::fabs((data_object->position.y + positions[id_vertex].y) + data_frame->position_player.y) + 
+      metal::fabs((data_object->position.z + positions[id_vertex].z) + data_frame->position_player.z)
+    );
+  }
+
+  return data_vertex;
+}
+
+fragment float4 zoe_tree_fragment(
+  struct data_vertex data_vertex [[stage_in]],
+  metal::texture2d<half> texture [[ texture(0) ]],
+  metal::texture2d<half> texture_two [[ texture(1) ]]
+) {
+  constexpr metal::sampler sampler_texture(
+    metal::filter::linear,
+    metal::mip_filter::linear
+  );
+
+  float4 texture_color = float4(
+    (
+      data_vertex.index_texture == 0
+      ? texture
+      : texture_two
+    ).sample(
+      sampler_texture,
+      data_vertex.position_texture
+    )
+  );
+
+  float brightness = (
+    ((data_vertex.height * 0.8f) + 0.075f) *
+    (data_vertex.brightness * 0.8f)
+  ) * metal::fmax(
+    metal::fmin(
+      100.0f / data_vertex.distance,
+      1.0f
+    ),
+    0.0f
+  );
+
+  return float4(
+    texture_color[0] * brightness,
+    texture_color[1] * brightness,
+    texture_color[2] * brightness,
+    texture_color[3]
+  );
+}

--- a/sources/pipeline_index.c
+++ b/sources/pipeline_index.c
@@ -1,0 +1,6 @@
+#include <zoe_pipeline_index.h>
+
+unsigned short int zoe_pipeline_index_ground = 0;
+unsigned short int zoe_pipeline_index_player = 0;
+unsigned short int zoe_pipeline_index_text = 0;
+unsigned short int zoe_pipeline_index_tree = 0;

--- a/sources/scenes/scene_intro_forest.m
+++ b/sources/scenes/scene_intro_forest.m
@@ -7,6 +7,7 @@
 #include <mesh/tree/mesh_tree.h>
 #include <mode_texture.h>
 #include <scenes/scene_id.h>
+#include <zoe_pipeline_index.h>
 
 #include <metil_object.h>
 #include <metil_scenes/scene.h>
@@ -21,7 +22,7 @@ void scene_intro_forest_data_initialize(
 
 void scene_intro_forest_initialize(
   struct metil_scene* scene,
-  id<MTLDevice> metal_kit_device
+  id<MTLDevice> metal_device
 ) {
   metil_audio_io_proc_add(
     scene_intro_forest_io_proc
@@ -29,7 +30,7 @@ void scene_intro_forest_initialize(
 
   metil_scene_initialize(
     scene,
-    metal_kit_device
+    metal_device
   );
 
   scene->type = metil_scene_type_game;
@@ -53,6 +54,10 @@ void scene_intro_forest_initialize(
     scene->objects[index_object] = malloc(
       sizeof(struct metil_object)
     );
+
+    metil_object_initialize(
+      scene->objects[index_object]
+    );
   }
 
   scene->length_textures = 3;
@@ -61,7 +66,7 @@ void scene_intro_forest_initialize(
     scene->length_textures
   );
 
-  MTKTextureLoader* texture_loader = [[MTKTextureLoader alloc] initWithDevice: metal_kit_device];
+  MTKTextureLoader* texture_loader = [[MTKTextureLoader alloc] initWithDevice: metal_device];
 
   scene->textures[
     textures_scene_intro_forest_ground
@@ -120,22 +125,12 @@ void scene_intro_forest_initialize(
     &scene->objects[0]->mesh
   );
 
-  scene->objects[0]->vertices = [metal_kit_device
-    newBufferWithBytes: scene->objects[0]->mesh.vertices
-    length: scene->objects[0]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-    options: MTLResourceStorageModeShared
-  ];
+  scene->objects[0]->index_pipeline_render = zoe_pipeline_index_player;
 
-  scene->objects[0]->indices = [metal_kit_device
-    newBufferWithBytes: scene->objects[0]->mesh.indices
-    length: scene->objects[0]->mesh.length_indices * sizeof(unsigned int)
-    options: MTLResourceStorageModeShared
-  ];
-
-  scene->objects[0]->data = [metal_kit_device
-    newBufferWithLength: sizeof(struct metil_renderer_data_object)
-    options: MTLResourceStorageModeShared
-  ];
+  metil_object_buffers_initialize(
+    scene->objects[0],
+    scene->metal_device
+  );
 
   scene->objects[0]->texture = scene->textures[
     textures_scene_intro_forest_player
@@ -151,22 +146,12 @@ void scene_intro_forest_initialize(
     &scene->objects[1]->mesh
   );
 
-  scene->objects[1]->vertices = [metal_kit_device
-    newBufferWithBytes: scene->objects[1]->mesh.vertices
-    length: scene->objects[1]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-    options: MTLResourceStorageModeShared
-  ];
+  scene->objects[1]->index_pipeline_render = zoe_pipeline_index_player;
 
-  scene->objects[1]->indices = [metal_kit_device
-    newBufferWithBytes: scene->objects[1]->mesh.indices
-    length: scene->objects[1]->mesh.length_indices * sizeof(unsigned int)
-    options: MTLResourceStorageModeShared
-  ];
-
-  scene->objects[1]->data = [metal_kit_device
-    newBufferWithLength: sizeof(struct metil_renderer_data_object)
-    options: MTLResourceStorageModeShared
-  ];
+  metil_object_buffers_initialize(
+    scene->objects[1],
+    scene->metal_device
+  );
 
   scene->objects[1]->texture = scene->textures[
     textures_scene_intro_forest_player
@@ -183,24 +168,14 @@ void scene_intro_forest_initialize(
     2000.0f
   );
 
+  scene->objects[2]->index_pipeline_render = zoe_pipeline_index_ground;
+
   scene->objects[2]->position.y = -10.0f;
 
-  scene->objects[2]->vertices = [metal_kit_device
-    newBufferWithBytes: scene->objects[2]->mesh.vertices
-    length: scene->objects[2]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-    options: MTLResourceStorageModeShared
-  ];
-
-  scene->objects[2]->indices = [metal_kit_device
-    newBufferWithBytes: scene->objects[2]->mesh.indices
-    length: scene->objects[2]->mesh.length_indices * sizeof(unsigned int)
-    options: MTLResourceStorageModeShared
-  ];
-
-  scene->objects[2]->data = [metal_kit_device
-    newBufferWithLength: sizeof(struct metil_renderer_data_object)
-    options: MTLResourceStorageModeShared
-  ];
+  metil_object_buffers_initialize(
+    scene->objects[2],
+    scene->metal_device
+  );
 
   scene->objects[2]->texture = scene->textures[
     textures_scene_intro_forest_ground
@@ -224,6 +199,8 @@ void scene_intro_forest_initialize(
       1.0f,
       250.0f
     );
+    
+    scene->objects[index_object]->index_pipeline_render = zoe_pipeline_index_tree;
 
     scene->objects[index_object]->position.x = (
       -(scene->objects[index_object]->mesh.size.x / 2.0f) + (
@@ -241,25 +218,10 @@ void scene_intro_forest_initialize(
       )
     );
 
-    scene->objects[index_object]->vertices = [metal_kit_device
-      newBufferWithBytes: scene->objects[index_object]->mesh.vertices
-      length: scene->objects[index_object]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-      options: MTLResourceStorageModeShared
-    ];
-
-    scene->objects[index_object]->indices = [metal_kit_device
-      newBufferWithBytes: scene->objects[index_object]->mesh.indices
-      length: (
-        sizeof(unsigned int) *
-        scene->objects[index_object]->mesh.length_indices
-      )
-      options: MTLResourceStorageModePrivate
-    ];
-
-    scene->objects[index_object]->data = [metal_kit_device
-      newBufferWithLength: sizeof(struct metil_renderer_data_object)
-      options: MTLResourceStorageModeShared
-    ];
+    metil_object_buffers_initialize(
+      scene->objects[index_object],
+      scene->metal_device
+    );
 
     struct metil_renderer_data_object* data = scene->objects[index_object]->data.contents;
     

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -7,6 +7,7 @@
 #include <mesh/tree/mesh_tree.h>
 #include <mode_texture.h>
 #include <scenes/scene_id.h>
+#include <zoe_pipeline_index.h>
 
 #include <metil.h>
 
@@ -18,7 +19,7 @@ const unsigned long int scene_menu_main_time_scene_transition = 333;
 
 void scene_menu_main_initialize(
   struct metil_scene* scene,
-  id<MTLDevice> metal_kit_device
+  id<MTLDevice> metal_device
 ) {
   metil_audio_io_proc_add(
     scene_menu_main_io_proc
@@ -26,7 +27,7 @@ void scene_menu_main_initialize(
 
   metil_scene_initialize(
     scene,
-    metal_kit_device
+    metal_device
   );
 
   scene->poll = scene_menu_main_poll;
@@ -65,7 +66,7 @@ void scene_menu_main_initialize(
     scene->length_textures
   );
 
-  MTKTextureLoader* texture_loader = [[MTKTextureLoader alloc] initWithDevice: metal_kit_device];
+  MTKTextureLoader* texture_loader = [[MTKTextureLoader alloc] initWithDevice: metal_device];
 
   scene->textures[
     textures_scene_menu_main_ground
@@ -103,6 +104,10 @@ void scene_menu_main_initialize(
 
   [texture_loader release];
 
+  metil_object_initialize(
+    scene->objects[0]
+  );
+
   mesh_ground_initialize(
     &scene->objects[0]->mesh,
     666.0f,
@@ -110,22 +115,14 @@ void scene_menu_main_initialize(
     666.0f
   );
 
-  scene->objects[0]->vertices = [metal_kit_device
-    newBufferWithBytes: scene->objects[0]->mesh.vertices
-    length: scene->objects[0]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-    options: MTLResourceStorageModeShared
-  ];
+  metil_object_buffers_initialize(
+    scene->objects[0],
+    scene->metal_device
+  );
 
-  scene->objects[0]->indices = [metal_kit_device
-    newBufferWithBytes: scene->objects[0]->mesh.indices
-    length: scene->objects[0]->mesh.length_indices * sizeof(unsigned int)
-    options: MTLResourceStorageModeShared
-  ];
-
-  scene->objects[0]->data = [metal_kit_device
-    newBufferWithLength: sizeof(struct metil_renderer_data_object)
-    options: MTLResourceStorageModeShared
-  ];
+  scene->objects[0]->index_pipeline_render = (
+    zoe_pipeline_index_ground
+  );
 
   scene->objects[0]->texture = scene->textures[
     textures_scene_menu_main_ground
@@ -146,31 +143,24 @@ void scene_menu_main_initialize(
     sizeof(struct metil_object)
   );
 
+  metil_object_initialize(
+    scene->objects[1]
+  );
+
   mesh_tree_initialize(
     &(scene->objects[1]->mesh),
     1.0f,
     66.6f
   );
 
-  scene->objects[1]->vertices = [metal_kit_device
-    newBufferWithBytes: scene->objects[1]->mesh.vertices
-    length: scene->objects[1]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-    options: MTLResourceStorageModeShared
-  ];
+  scene->objects[1]->index_pipeline_render = (
+    zoe_pipeline_index_tree
+  );
 
-  scene->objects[1]->indices = [metal_kit_device
-    newBufferWithBytes: scene->objects[1]->mesh.indices
-    length: (
-      sizeof(unsigned int) *
-      scene->objects[1]->mesh.length_indices
-    )
-    options: MTLResourceStorageModePrivate
-  ];
-
-  scene->objects[1]->data = [metal_kit_device
-    newBufferWithLength: sizeof(struct metil_renderer_data_object)
-    options: MTLResourceStorageModeShared
-  ];
+  metil_object_buffers_initialize(
+    scene->objects[1],
+    scene->metal_device
+  );
 
   data_object = scene->objects[1]->data.contents;
   
@@ -186,35 +176,28 @@ void scene_menu_main_initialize(
     sizeof(struct metil_object)
   );
 
+  metil_object_initialize(
+    scene->objects[2]
+  );
+
+  scene->objects[2]->index_pipeline_render = (
+    zoe_pipeline_index_text
+  );
+
   scene->textures[
     textures_scene_menu_main_title
   ] = metil_text_mesh_with_texture_initialize(
-    metal_kit_device,
+    metal_device,
     &scene->objects[2]->mesh,
     "zoe",
     metil_font_reference_monospace,
     0.001f
   );
 
-  scene->objects[2]->vertices = [metal_kit_device
-    newBufferWithBytes: scene->objects[2]->mesh.vertices
-    length: scene->objects[2]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-    options: MTLResourceStorageModeShared
-  ];
-
-  scene->objects[2]->indices = [metal_kit_device
-    newBufferWithBytes: scene->objects[2]->mesh.indices
-    length: (
-      sizeof(unsigned int) *
-      scene->objects[2]->mesh.length_indices
-    )
-    options: MTLResourceStorageModePrivate
-  ];
-
-  scene->objects[2]->data = [metal_kit_device
-    newBufferWithLength: sizeof(struct metil_renderer_data_object)
-    options: MTLResourceStorageModeShared
-  ];
+  metil_object_buffers_initialize(
+    scene->objects[2],
+    scene->metal_device
+  );
 
   scene->objects[2]->position.y = 0.5f - (scene->objects[2]->mesh.size.y / 4.0f);
 
@@ -232,35 +215,28 @@ void scene_menu_main_initialize(
     sizeof(struct metil_object)
   );
 
+  metil_object_initialize(
+    scene->objects[3]
+  );
+
+  scene->objects[3]->index_pipeline_render = (
+    zoe_pipeline_index_text
+  );
+
   scene->textures[
     textures_scene_menu_main_menu_enter
   ] = metil_text_mesh_with_texture_initialize(
-    metal_kit_device,
+    metal_device,
     &scene->objects[3]->mesh,
     "enter",
     metil_font_reference_monospace,
     0.001f
   );
 
-  scene->objects[3]->vertices = [metal_kit_device
-    newBufferWithBytes: scene->objects[3]->mesh.vertices
-    length: scene->objects[3]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-    options: MTLResourceStorageModeShared
-  ];
-
-  scene->objects[3]->indices = [metal_kit_device
-    newBufferWithBytes: scene->objects[3]->mesh.indices
-    length: (
-      sizeof(unsigned int) *
-      scene->objects[3]->mesh.length_indices
-    )
-    options: MTLResourceStorageModePrivate
-  ];
-
-  scene->objects[3]->data = [metal_kit_device
-    newBufferWithLength: sizeof(struct metil_renderer_data_object)
-    options: MTLResourceStorageModeShared
-  ];
+  metil_object_buffers_initialize(
+    scene->objects[3],
+    scene->metal_device
+  );
 
   scene->objects[3]->position.y = -scene->objects[3]->mesh.size.y * 6.0;
 
@@ -277,35 +253,28 @@ void scene_menu_main_initialize(
     sizeof(struct metil_object)
   );
 
+  metil_object_initialize(
+    scene->objects[4]
+  );
+
+  scene->objects[4]->index_pipeline_render = (
+    zoe_pipeline_index_text
+  );
+
   scene->textures[
     textures_scene_menu_main_menu_exit
   ] = metil_text_mesh_with_texture_initialize(
-    metal_kit_device,
+    metal_device,
     &scene->objects[4]->mesh,
     "exit",
     metil_font_reference_monospace,
     0.001f
   );
 
-  scene->objects[4]->vertices = [metal_kit_device
-    newBufferWithBytes: scene->objects[4]->mesh.vertices
-    length: scene->objects[4]->mesh.length_vertices * sizeof(struct clic3_vector4_float)
-    options: MTLResourceStorageModeShared
-  ];
-
-  scene->objects[4]->indices = [metal_kit_device
-    newBufferWithBytes: scene->objects[4]->mesh.indices
-    length: (
-      sizeof(unsigned int) *
-      scene->objects[4]->mesh.length_indices
-    )
-    options: MTLResourceStorageModePrivate
-  ];
-
-  scene->objects[4]->data = [metal_kit_device
-    newBufferWithLength: sizeof(struct metil_renderer_data_object)
-    options: MTLResourceStorageModeShared
-  ];
+  metil_object_buffers_initialize(
+    scene->objects[4],
+    scene->metal_device
+  );
 
   scene->objects[4]->position.y = -scene->objects[4]->mesh.size.y * 10.0f;
 

--- a/sources/zoe.m
+++ b/sources/zoe.m
@@ -3,16 +3,16 @@
 #include <scenes/scene_id.h>
 #include <scenes/scene_intro_forest.h>
 #include <scenes/scene_menu_main.h>
+#include <zoe_pipeline_index.h>
 
-#include <metil.h>
-
-#include <AppKit/AppKit.h>
+#include <metil_initialize.h>
+#include <metil_rendering/metil_renderer_interface.h>
 
 int main(
   int length_parameters,
   const char** parameters
 ) {
-  metil_player_speed_movement_default = 32.0f;
+  metil_player_speed_movement_default = 64.0f;
 
   return metil_initialize(
     length_parameters,
@@ -23,47 +23,90 @@ int main(
 }
 
 void zoe_renderer_on_initialize(
-  id<MTLDevice> metal_kit_device,
-  struct metil_rendering_properties* metil_rendering_properties,
+  struct metil_renderer_interface* metil_renderer_interface,
   void* data
 ) {
-  metil_library.library = [metal_kit_device newDefaultLibrary];
-
-  metil_library.function_vertex = [
-    metil_library.library
-    newFunctionWithName: @"zoe_shader_vertex"
+  metil_library.library = [
+    metil_renderer_interface->metal_device
+    newDefaultLibrary
   ];
 
   metil_library.function_fragment = [
     metil_library.library
-    newFunctionWithName: @"zoe_shader_fragment"
+    newFunctionWithName: @"zoe_default_fragment"
   ];
 
-  metil_library.library_fps_display = [metal_kit_device newDefaultLibrary];
-
-  metil_library.function_vertex_fps_display = [
+  metil_library.function_vertex = [
     metil_library.library
-    newFunctionWithName: @"metil_fps_display_vertex"
+    newFunctionWithName: @"zoe_default_vertex"
   ];
 
-  metil_library.function_fragment_fps_display = [
-    metil_library.library
-    newFunctionWithName: @"metil_fps_display_fragment"
+  metil_library_fps_display_initialize(
+    metil_renderer_interface->metal_device,
+    (void*)0
+  );
+
+  zoe_pipeline_index_ground = [
+    metil_renderer_interface->renderer
+    pipeline_add: [
+      metil_library.library
+      newFunctionWithName: @"zoe_ground_fragment"
+    ]
+    function_vertex: [
+      metil_library.library
+      newFunctionWithName: @"zoe_ground_vertex"
+    ]
   ];
 
-  metil_rendering_properties->color_clear.x = 0.0324f;
-  metil_rendering_properties->color_clear.y = 0.0424f;
-  metil_rendering_properties->color_clear.z = 0.0649f;
-  metil_rendering_properties->color_clear.w = 1.0f;
+  zoe_pipeline_index_player = [
+    metil_renderer_interface->renderer
+    pipeline_add: [
+      metil_library.library
+      newFunctionWithName: @"zoe_player_fragment"
+    ]
+    function_vertex: [
+      metil_library.library
+      newFunctionWithName: @"zoe_player_vertex"
+    ]
+  ];
+
+  zoe_pipeline_index_text = [
+    metil_renderer_interface->renderer
+    pipeline_add: [
+      metil_library.library
+      newFunctionWithName: @"zoe_text_fragment"
+    ]
+    function_vertex: [
+      metil_library.library
+      newFunctionWithName: @"zoe_text_vertex"
+    ]
+  ];
+
+  zoe_pipeline_index_tree = [
+    metil_renderer_interface->renderer
+    pipeline_add: [
+      metil_library.library
+      newFunctionWithName: @"zoe_tree_fragment"
+    ]
+    function_vertex: [
+      metil_library.library
+      newFunctionWithName: @"zoe_tree_vertex"
+    ]
+  ];
+
+  metil_renderer_interface->rendering_properties->color_clear.x = 0.0324f;
+  metil_renderer_interface->rendering_properties->color_clear.y = 0.0424f;
+  metil_renderer_interface->rendering_properties->color_clear.z = 0.0649f;
+  metil_renderer_interface->rendering_properties->color_clear.w = 1.0f;
 
   scene_menu_main_initialize(
     &metil_scene_controller.scene,
-    metal_kit_device
+    metil_renderer_interface->metal_device
   );
 
   metil_scene_controller_on_scene_change_add(
     zoe_on_scene_change,
-    metal_kit_device
+    metil_renderer_interface
   );
 }
 
@@ -71,8 +114,8 @@ void zoe_on_scene_change(
   int id_scene,
   void* data
 ) {
-  id<MTLDevice> metal_kit_device = (
-    (id<MTLDevice>) data
+  struct metil_renderer_interface* metil_renderer_interface = (
+    (struct metil_renderer_interface*) data
   );
 
   metil_scene_destroy(
@@ -86,13 +129,13 @@ void zoe_on_scene_change(
     case scene_id_menu_main:
       scene_menu_main_initialize(
         &metil_scene_controller.scene,
-        metal_kit_device
+        metil_renderer_interface->metal_device
       );
       break;
     case scene_id_intro_forest:
       scene_intro_forest_initialize(
         &metil_scene_controller.scene,
-        metal_kit_device
+        metil_renderer_interface->metal_device
       );
       break;
   }


### PR DESCRIPTION
- fix header defines
- use multiple `*.metal` files
- - use multiple render pipelines
- `zoe_pipeline_index`:add
- `metal_kit_device`->`metal_device`
- double movement speed