### PR TITLE
[bug] Metil 1 0 0 compatibility third person rendering ios build

### DIFF
--- a/include/scenes/scene_menu_main.h
+++ b/include/scenes/scene_menu_main.h
@@ -11,7 +11,9 @@
 #include <rand_result.h>
 #include <rand_source.h>
 
-#if !target_os_ios
+#if target_os_ios
+#include <AVFAudio/AVFAudio.h>
+#else
 #include <CoreAudio/CoreAudio.h>
 #endif
 #include <MetalKit/MetalKit.h>


### PR DESCRIPTION
- `scene_menu_main`:add->{`AVFAudio`};