### PR TITLE
[bug|dev|enh] Intro hill: additions->{position_y_floor usage | fix mesh hill percentage values | bind movement};

### DIFF
--- a/sources/menus/menu_main.m
+++ b/sources/menus/menu_main.m
@@ -12,13 +12,13 @@ void menu_main_initialize(
     menu,
     metil_menu_item_type_selection,
     metil_menu_item_action_select,
-    (void*)0
+    (void*) 0
   );
 
   metil_menu_item_add(
     menu,
     metil_menu_item_type_selection,
     metil_menu_item_action_select,
-    (void*)0
+    (void*) 0
   );
 }

--- a/sources/mesh/mesh_hill.c
+++ b/sources/mesh/mesh_hill.c
@@ -63,11 +63,11 @@ void mesh_hill_initialize(
   const struct clic3_vector2_float increment_hill = {
     .x = (
       metil_mesh->size.x /
-      (float) (mesh_hill_length_vertices.x)
+      (float) (mesh_hill_length_vertices.x - 1)
     ),
     .y = (
       metil_mesh->size.z /
-      (float) (mesh_hill_length_vertices.y)
+      (float) (mesh_hill_length_vertices.y - 1)
     )
   };
 

--- a/sources/scenes/scene_intro_forest.m
+++ b/sources/scenes/scene_intro_forest.m
@@ -118,8 +118,8 @@ void scene_intro_forest_initialize(
         isDirectory: 1
       ]
     ]
-    options: (void*)0
-    error: (void*)0
+    options: (void*) 0
+    error: (void*) 0
   ];
 
   scene->textures[
@@ -135,8 +135,8 @@ void scene_intro_forest_initialize(
         isDirectory: 1
       ]
     ]
-    options: (void*)0
-    error: (void*)0
+    options: (void*) 0
+    error: (void*) 0
   ];
 
   scene->textures[
@@ -152,8 +152,8 @@ void scene_intro_forest_initialize(
         isDirectory: 1
       ]
     ]
-    options: (void*)0
-    error: (void*)0
+    options: (void*) 0
+    error: (void*) 0
   ];
 
   [texture_loader release];

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -188,6 +188,20 @@ void scene_intro_hill_initialize(
     0
   );
 
+  scene->player.size.x = (
+    object->mesh.size.x /
+    2.0f
+  );
+
+  scene->player.size.y = (
+    object->mesh.size.y
+  );
+
+  scene->player.size.z = (
+    object->mesh.size.z /
+    2.0f
+  );
+
   object = (
     scene->renderables[
       scene_intro_hill_index_renderable_player_mirror
@@ -273,6 +287,52 @@ void scene_intro_hill_poll(
     metil,
     scene
   );
+
+  scene->player.speed_movement = 100.0f;
+
+  if (
+    length_vertices_hill_x < (
+      scene->player.position.x +
+      scene->player.size.x
+    )
+  ) {
+    scene->player.position.x = (
+      length_vertices_hill_x -
+      scene->player.size.x
+    );
+  } else if (
+    -length_vertices_hill_x > (
+      scene->player.position.x -
+      scene->player.size.x
+    )
+  ) {
+    scene->player.position.x = (
+      -length_vertices_hill_x +
+      scene->player.size.x
+    );
+  }
+
+  if (
+    length_vertices_hill_y < (
+      scene->player.position.z +
+      scene->player.size.z
+    )
+  ) {
+    scene->player.position.z = (
+      length_vertices_hill_y -
+      scene->player.size.z
+    );
+  } else if (
+    -length_vertices_hill_y > (
+      scene->player.position.z -
+      scene->player.size.z
+    )
+  ) {
+    scene->player.position.z = (
+      -length_vertices_hill_y +
+      scene->player.size.z
+    );
+  }
 
   struct clic3_vector2_float position_percentage = {
     .x = (

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -291,7 +291,7 @@ void scene_intro_hill_poll(
     )
   };
 
-  scene->player.position.y = (
+  scene->player.position_y_floor = (
     hill_y_value_get(
       &position_percentage
     )

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -278,14 +278,16 @@ void scene_intro_hill_poll(
     .x = (
       math_c_absolute_float(
         scene->player.position.x / (
-          length_vertices_hill_x
+          length_vertices_hill_x -
+          1
         )
       ) / 2.0f
     ),
     .y = (
       math_c_absolute_float(
         scene->player.position.z / (
-          length_vertices_hill_y
+          length_vertices_hill_y -
+          1
         )
       ) / 2.0f
     )

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -133,8 +133,8 @@ void scene_intro_hill_initialize(
         isDirectory: 1
       ]
     ]
-    options: (void*)0
-    error: (void*)0
+    options: (void*) 0
+    error: (void*) 0
   ];
 
   scene->textures[
@@ -150,8 +150,8 @@ void scene_intro_hill_initialize(
         isDirectory: 1
       ]
     ]
-    options: (void*)0
-    error: (void*)0
+    options: (void*) 0
+    error: (void*) 0
   ];
 
   scene->textures[
@@ -167,8 +167,8 @@ void scene_intro_hill_initialize(
         isDirectory: 1
       ]
     ]
-    options: (void*)0
-    error: (void*)0
+    options: (void*) 0
+    error: (void*) 0
   ];
 
   [texture_loader release];

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -118,8 +118,8 @@ void scene_menu_main_initialize(
         isDirectory: 1
       ]
     ]
-    options: (void*)0
-    error: (void*)0
+    options: (void*) 0
+    error: (void*) 0
   ];
 
   scene->textures[
@@ -135,8 +135,8 @@ void scene_menu_main_initialize(
         isDirectory: 1
       ]
     ]
-    options: (void*)0
-    error: (void*)0
+    options: (void*) 0
+    error: (void*) 0
   ];
 
   [texture_loader release];


### PR DESCRIPTION
- spaces out void pointer casts
- use `position_y_floor` to allow y movement
- fix mesh hill percentages in y value and mesh vertex positioning
- bind player movement within `mesh_hill` area


<img width="1966" height="1250" alt="Screenshot 2026-01-04 at 22 29 05" src="https://github.com/user-attachments/assets/08de9801-8394-45b9-b30f-aa9d71335125" />
