### PR TITLE
[bug] `scene_menu_main`:multiply_brightness_transition_by_configured_brightness

### DIFF
--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -346,8 +346,15 @@ void scene_menu_main_poll(
         (float) scene_menu_main_time_scene_transition
       );
 
-      metil->rendering_properties.brightness = brightness;
-      metil->rendering_properties.brightness_text = brightness;
+      metil->rendering_properties.brightness = (
+        metil->configuration.rendering_properties.brightness *
+        brightness
+      );
+
+      metil->rendering_properties.brightness_text = (
+        metil->configuration.rendering_properties.brightness_text *
+        brightness
+      );
     }
   } else if (
     menu->index_selected != -1 &&


### PR DESCRIPTION
- `scene_menu_main`
- - adjust brightness accordingly with the configured brightness level