### PR TITLE
[enh] Tree collision detection

### DIFF
--- a/sources/scenes/scene_intro_forest.m
+++ b/sources/scenes/scene_intro_forest.m
@@ -9,6 +9,7 @@
 
 #include <metil_audio/metil_audio_io_proc.h>
 #include <metil_audio/metil_audio_io_proc_data.h>
+#include <metil_collision/metil_collision_uncollide/metil_collision_uncollide_circular.h>
 #include <metil_object/metil_object.h>
 #include <metil_object/metil_object_buffer.h>
 #include <metil_paths/metil_paths.h>
@@ -36,6 +37,14 @@ void scene_intro_forest_initialize(
   struct metil* metil,
   struct metil_scene* scene
 ) {
+  metil->rendering_properties.brightness = (
+    metil->configuration.rendering_properties.brightness
+  );
+
+  metil->rendering_properties.brightness_text = (
+    metil->configuration.rendering_properties.brightness_text
+  );
+
   metil->rendering_properties.camera.mode = (
     metil_camera_mode_third_person
   );
@@ -173,6 +182,20 @@ void scene_intro_forest_initialize(
     0
   );
 
+  scene->player.size.x = (
+    object->mesh.size.x /
+    2.0f
+  );
+
+  scene->player.size.y = (
+    object->mesh.size.y
+  );
+
+  scene->player.size.z = (
+    object->mesh.size.z /
+    2.0f
+  );
+
   object = (
     scene->renderables[
       1
@@ -306,15 +329,16 @@ void scene_intro_forest_poll(
     index_renderable < scene->length_renderables;
     ++index_renderable
   ) {
-    struct metil_object* metil_object = (
+    struct metil_object* metil_object_tree = (
       scene->renderables[
         index_renderable
       ].renderable
     );
 
-    struct math_c_vector3_float* vertices = metil_object->buffers_vertex[
-      metil_object_buffer_default_index_vertices
-    ].buffer.contents;
+    metil_collision_player_object_uncollide_circular_xz(
+      metil_object_tree,
+      &scene->player
+    );
   }
 }
 

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -449,11 +449,9 @@ void scene_intro_hill_poll(
       }
     }
 
-    metil_collision_uncollide_circular_xz(
-      &metil_object_tree->position,
-      &metil_object_tree->mesh.size,
-      &scene->player.position,
-      &scene->player.size
+    metil_collision_player_object_uncollide_circular_xz(
+      metil_object_tree,
+      &scene->player
     );
   }
 

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -13,6 +13,7 @@
 #include <metil.h>
 #include <metil_audio/metil_audio_io_proc.h>
 #include <metil_audio/metil_audio_io_proc_data.h>
+#include <metil_collision/metil_collision_uncollide/metil_collision_uncollide_circular.h>
 #include <metil_group.h>
 #include <metil_object/metil_object.h>
 #include <metil_object/metil_object_buffer.h>
@@ -414,6 +415,45 @@ void scene_intro_hill_poll(
     scene->player.position.z = (
       -length_vertices_hill_y +
       scene->player.size.z
+    );
+  }
+
+  struct metil_object* metil_object_tree;
+
+  for (
+    unsigned char index_tree = 0;
+    index_tree < 2;
+    ++index_tree
+  ) {
+    switch (
+      index_tree
+    ) {
+      case 0: {
+        metil_object_tree = (
+          scene->renderables[
+            scene_intro_hill_index_renderable_tree_zoe
+          ].renderable
+        );
+        
+        break;
+      }
+      default:
+      case 1: {
+        metil_object_tree = (
+          scene->renderables[
+            scene_intro_hill_index_renderable_tree_zoe_mirror
+          ].renderable
+        );
+
+        break;
+      }
+    }
+
+    metil_collision_uncollide_circular_xz(
+      &metil_object_tree->position,
+      &metil_object_tree->mesh.size,
+      &scene->player.position,
+      &scene->player.size
     );
   }
 


### PR DESCRIPTION
- adds collision detection to trees

i considered putting this into the `poll` function pointer on the object itself but that doesn't work correctly since the matrixes are precalculated with the player position.

one thing i may do is create two seperate `poll` functions, one which calculates the view projections and the other one which is a standard `poll`. that way i can update player/object position before viewport calculations are being handled