### PR TITLE
[bug|dev|enh] Scene change: hill -> forest

### DIFF
--- a/include/data/data_player.h
+++ b/include/data/data_player.h
@@ -1,0 +1,21 @@
+#ifndef __data_data_player_h
+#define __data_data_player_h
+
+enum data_player_action {
+  data_player_action_none = 0b00000000,
+  data_player_action_select = 0b00000001
+};
+
+struct data_player {
+  unsigned char actions;
+};
+
+void data_player_initialize(
+  struct data_player*
+);
+
+void data_player_destroy(
+  struct data_player*
+);
+
+#endif

--- a/include/data/data_zoe.h
+++ b/include/data/data_zoe.h
@@ -1,0 +1,14 @@
+#ifndef __data_data_zoe_h
+#define __data_data_zoe_h
+
+#include <data/data_player.h>
+
+struct data_zoe {
+  struct data_player player;
+};
+
+void data_zoe_initialize(
+  struct data_zoe*
+);
+
+#endif

--- a/include/input/input_movement.h
+++ b/include/input/input_movement.h
@@ -1,0 +1,14 @@
+#ifndef __input_input_movement_h
+#define __input_input_movement_h
+
+#include <metil.h>
+#include <metil_player/metil_player.h>
+
+void zoe_input_movement(
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull,
+  unsigned long int,
+  unsigned long int
+);
+
+#endif

--- a/include/scenes/scene_intro_forest.h
+++ b/include/scenes/scene_intro_forest.h
@@ -13,6 +13,16 @@
 #endif
 #include <MetalKit/MetalKit.h>
 
+#define scene_intro_forest_length_renderables 4
+#define scene_intro_forest_length_group_trees_renderables 1000
+
+enum scene_intro_forest_index_renderable {
+  scene_intro_forest_index_renderable_ground = 0,
+  scene_intro_forest_index_renderable_player = 1,
+  scene_intro_forest_index_renderable_player_mirror = 2,
+  scene_intro_forest_index_renderable_group_trees = 3,
+};
+
 enum textures_scene_intro_forest {
   textures_scene_intro_forest_ground = 0,
   textures_scene_intro_forest_tree = 1,

--- a/include/zoe.h
+++ b/include/zoe.h
@@ -31,4 +31,8 @@ void zoe_on_scene_change(
   void* _Nonnull
 );
 
+void zoe_destroy(
+  struct metil* _Nonnull
+);
+
 #endif

--- a/sources/data/data_player.c
+++ b/sources/data/data_player.c
@@ -1,0 +1,13 @@
+#include <data/data_player.h>
+
+void data_player_initialize(
+  struct data_player* data_player
+) {
+  data_player->actions = (
+    data_player_action_none
+  );
+}
+
+void data_player_destroy(
+  struct data_player* data_player
+) {}

--- a/sources/data/data_zoe.c
+++ b/sources/data/data_zoe.c
@@ -1,0 +1,19 @@
+#include <data/data_zoe.h>
+
+#include <data/data_player.h>
+
+void data_zoe_initialize(
+  struct data_zoe* data_zoe
+) {
+  data_player_initialize(
+    &data_zoe->player
+  );
+}
+
+void data_zoe_destroy(
+  struct data_zoe* data_zoe
+) {
+  data_player_destroy(
+    &data_zoe->player
+  );
+}

--- a/sources/input/input_movement.m
+++ b/sources/input/input_movement.m
@@ -1,0 +1,434 @@
+#include <input/input_movement.h>
+
+#include <data/data_player.h>
+
+#include <math_c_vector.h>
+
+#include <metil.h>
+#include <metil_input/metil_input.h>
+#include <metil_input/metil_keycodes.h>
+#include <metil_player/metil_player.h>
+#include <metil_player/metil_player_defaults.h>
+
+void zoe_input_movement(
+  struct metil* metil,
+  struct metil_player* metil_player,
+  unsigned long int time,
+  unsigned long int time_delta
+) {
+  struct data_player* data_player = (
+    metil_player->data
+  );
+
+  float speed_original = (
+    metil_player->speed_movement
+  );
+
+  float speed_delta = (
+    (float) time_delta /
+    1000.0f
+  );
+
+  metil_player->speed_movement = (
+    metil_player->speed_movement *
+    speed_delta
+  );
+
+  if (
+    metil->input.keydown_map[
+      metil_keycode_e
+    ] == 1 ||
+    metil->input.keydown_map[
+      metil_keycode_o
+    ] == 1
+  ) {
+    data_player->actions = (
+      data_player->actions |
+      data_player_action_select
+    );
+  }
+
+  if (
+    metil->input.controller_state.available == 1 &&
+    metil->input.controller_state.l2 >= 0.1f &&
+    metil->input.controller_state.l3 == 0.0f
+  ) {
+    metil_player->speed_movement = (
+      metil_player->speed_movement *
+      (metil->input.controller_state.l2 + 1.0f)
+    );
+  } else if (
+    metil->input.controller_state.available == 1 &&
+    metil->input.controller_state.l2 < 0.1f &&
+    metil->input.controller_state.l3 >= 0.1f
+  ) {
+    metil_player->speed_movement = (
+      metil_player->speed_movement / (
+        metil->input.controller_state.l3 + 1.0f
+      )
+    );
+  } else if (
+    (
+      metil->input.keydown_map[
+        metil_keycode_option_right
+      ] == 1 ||
+      metil->input.keydown_map[
+        metil_keycode_control
+      ] == 1
+    )  && (
+      metil->input.keydown_map[
+        metil_keycode_shift_left
+      ] == 0 &&
+      metil->input.keydown_map[
+        metil_keycode_shift_right
+      ] == 0
+    )
+  ) {
+    metil_player->speed_movement = (
+      metil_player->speed_movement / 2.0f
+    );
+  } else if (
+    (
+      metil->input.keydown_map[
+        metil_keycode_option_right
+      ] == 0 &&
+      metil->input.keydown_map[
+        metil_keycode_control
+      ] == 0
+    ) && (
+      metil->input.keydown_map[
+        metil_keycode_shift_left
+      ] == 1 ||
+      metil->input.keydown_map[
+        metil_keycode_shift_right
+      ] == 1
+    )
+  ) {
+    metil_player->speed_movement = (
+      metil_player->speed_movement * 2.0f
+    );
+  }
+
+  struct math_c_vector3_float movement = {
+    .x = 0.0f,
+    .y = 0.0f,
+    .z = 0.0f
+  };
+
+  struct math_c_vector2_float ratio_movement = {
+    .x = 0.0f,
+    .y = 0.0f
+  };
+
+  struct math_c_vector2_float ratio_movement_strafe = {
+    .x = 0.0f,
+    .y = 0.0f
+  };
+
+  if (
+    metil->input.cursor.locked == 1
+  ) {
+    metil_player->rotation.y = (
+      metil_player->rotation.y - (
+        metil->input.cursor.delta.x / 50.0f *
+        metil_player->speed_rotation
+      )
+    );
+
+    metil_player->rotation.x = (
+      metil_player->rotation.x - (
+        metil->input.cursor.delta.y / 50.0f *
+        metil_player->speed_rotation
+      )
+    );
+
+    metil->input.cursor.delta.x = 0;
+    metil->input.cursor.delta.y = 0;
+  }
+
+  if (
+    metil->input.controller_state.available == 1
+  ) {
+    if (
+      metil->input.controller_state.right_stick.x >= metil_player->deadzone_stick ||
+      metil->input.controller_state.right_stick.x <= -metil_player->deadzone_stick
+    ) {
+      metil_player->rotation.y = (
+        metil_player->rotation.y - (
+          metil->input.controller_state.right_stick.x *
+          metil_player->speed_rotation
+        )
+      );
+    }
+
+    if (
+      metil->input.controller_state.right_stick.y >= metil_player->deadzone_stick ||
+      metil->input.controller_state.right_stick.y <= -metil_player->deadzone_stick
+    ) {
+      metil_player->rotation.x = (
+        metil_player->rotation.x + (
+          metil->input.controller_state.right_stick.y *
+          metil_player->speed_rotation
+        )
+      );
+    }
+  }
+
+  if (
+    metil_player->rotation.x > M_PI / 2.0f
+  ) {
+    metil_player->rotation.x = M_PI / 2.0f;
+  } else if (
+    metil_player->rotation.x < -M_PI / 2.0f
+  ) {
+    metil_player->rotation.x = -M_PI / 2.0f;
+  }
+
+  metil_player->rotation.y = fmod(
+    metil_player->rotation.y, (
+      M_PI * 2.0f
+    )
+  );
+
+  float ratio_axis = -(
+    metil_player->rotation.y / (
+      M_PI *
+      2.0f
+    )
+  );
+
+  if (
+    ratio_axis >= 0.0f &&
+    ratio_axis <= 0.25f
+  ) {
+    ratio_movement.y = (0.25f - ratio_axis) / 0.25f;
+    ratio_movement.x = (ratio_axis / 0.25f);
+
+    ratio_movement_strafe.y = -(ratio_axis / 0.25f);
+    ratio_movement_strafe.x = (0.25f - ratio_axis) / 0.25f;
+  } else if (
+    ratio_axis >= 0.25f &&
+    ratio_axis <= 0.5f
+  ) {
+    ratio_axis = ratio_axis - 0.25f;
+
+    ratio_movement.y = -(ratio_axis / 0.25f);
+    ratio_movement.x = (0.25f - ratio_axis) / 0.25f;
+
+    ratio_movement_strafe.y = -(0.25f - ratio_axis) / 0.25f;
+    ratio_movement_strafe.x = -(ratio_axis / 0.25f);
+  } else if (
+    ratio_axis >= 0.5f &&
+    ratio_axis <= 0.75f
+  ) {
+    ratio_axis = ratio_axis - 0.5f;
+
+    ratio_movement.y = -(0.25f - ratio_axis) / 0.25f;
+    ratio_movement.x = -(ratio_axis / 0.25f);
+
+    ratio_movement_strafe.y = (ratio_axis / 0.25f);
+    ratio_movement_strafe.x = -(0.25f - ratio_axis) / 0.25f;
+  } else if (
+    ratio_axis > 0.75f
+  ) {
+    ratio_axis = ratio_axis - 0.75f;
+
+    ratio_movement.y = (ratio_axis / 0.25f);
+    ratio_movement.x = -(0.25f - ratio_axis) / 0.25f;
+
+    ratio_movement_strafe.y = (0.25f - ratio_axis) / 0.25f;
+    ratio_movement_strafe.x = (ratio_axis / 0.25f);
+  } else if (
+    ratio_axis >= -0.25f
+  ) {
+    ratio_movement.y = (-0.25f - ratio_axis) / -0.25f;
+    ratio_movement.x = (ratio_axis / 0.25f);
+
+    ratio_movement_strafe.y = -(ratio_axis / 0.25f);
+    ratio_movement_strafe.x = (-0.25f - ratio_axis) / -0.25f;
+  } else if (
+    ratio_axis <= -0.25f &&
+    ratio_axis >= -0.5f
+  ) {
+    ratio_axis = ratio_axis + 0.25f;
+
+    ratio_movement.y = -(ratio_axis / -0.25f);
+    ratio_movement.x = (-0.25f - ratio_axis) / 0.25f;
+
+    ratio_movement_strafe.y = -(-0.25f - ratio_axis) / 0.25f;
+    ratio_movement_strafe.x = -(ratio_axis / -0.25f);
+  } else if (
+    ratio_axis <= -0.5f &&
+    ratio_axis >= -0.75f
+  ) {
+    ratio_axis = ratio_axis + 0.5f;
+
+    ratio_movement.y = -(-0.25f - ratio_axis) / -0.25f;
+    ratio_movement.x = -(ratio_axis / 0.25f);
+
+    ratio_movement_strafe.y = (ratio_axis / 0.25f);
+    ratio_movement_strafe.x = -(-0.25f - ratio_axis) / -0.25f;
+  } else {
+    ratio_axis = ratio_axis + 0.75f;
+
+    ratio_movement.y = (ratio_axis / -0.25f);
+    ratio_movement.x = -(-0.25f - ratio_axis) / 0.25f;
+
+    ratio_movement_strafe.y = (-0.25f - ratio_axis) / 0.25f;
+    ratio_movement_strafe.x = (ratio_axis / -0.25f);
+  }
+
+  if (
+    metil->input.controller_state.available == 1 &&
+    metil->input.controller_state.left_stick.x != 0.0f ||
+    metil->input.controller_state.left_stick.y != 0.0f
+  ) {
+    movement.x = (
+      (metil->input.controller_state.left_stick.y * ratio_movement.x) +
+      (metil->input.controller_state.left_stick.x * ratio_movement_strafe.x)
+    );
+
+    movement.z = (
+      (metil->input.controller_state.left_stick.y * ratio_movement.y) +
+      (metil->input.controller_state.left_stick.x * ratio_movement_strafe.y)
+    );
+  } else {
+    struct math_c_vector2_float direction_arrows = {
+      .x = (
+        (
+          metil->input.keydown_map[
+            metil_keycode_right_arrow
+          ] ||
+          metil->input.keydown_map[
+            metil_keycode_d
+          ] ||
+          metil->input.keydown_map[
+            metil_keycode_single_quote
+          ]
+        ) - (
+          metil->input.keydown_map[
+            metil_keycode_left_arrow
+          ] ||
+          metil->input.keydown_map[
+            metil_keycode_a
+          ] ||
+          metil->input.keydown_map[
+            metil_keycode_l
+          ]
+        )
+      ),
+      .y = (
+        (
+          metil->input.keydown_map[
+            metil_keycode_up_arrow
+          ] ||
+          metil->input.keydown_map[
+            metil_keycode_w
+          ] ||
+          metil->input.keydown_map[
+            metil_keycode_p
+          ]
+        ) - (
+          metil->input.keydown_map[
+            metil_keycode_down_arrow
+          ] ||
+          metil->input.keydown_map[
+            metil_keycode_s
+          ] ||
+          metil->input.keydown_map[
+            metil_keycode_semi_colon
+          ]
+        )
+      )
+    };
+
+    if (
+      direction_arrows.x != 0.0f &&
+      direction_arrows.y != 0.0f
+    ) {
+      direction_arrows.x = (
+        direction_arrows.x * 0.82f
+      );
+
+      direction_arrows.y = (
+        direction_arrows.y * 0.82f
+      );
+    }
+
+    movement.x = (
+      direction_arrows.y * ratio_movement.x +
+      direction_arrows.x * ratio_movement_strafe.x
+    );
+
+    movement.z = (
+      direction_arrows.y * ratio_movement.y +
+      direction_arrows.x * ratio_movement_strafe.y
+    );
+  }
+
+  if (
+    (
+      metil->input.keydown_map[
+        metil_keycode_space
+      ] == 1 || (
+        metil->input.controller_state.available == 1 &&
+        metil->input.controller_state.cross >= 0.1f
+      )
+    ) &&
+    metil_player->velocity.y == 0.0f
+  ) {
+    metil_player->velocity.y = (
+      speed_original /
+      1.25f
+    );
+  }
+
+  metil_player->position.x = (
+    metil_player->position.x + (
+      movement.x *
+      metil_player->speed_movement
+    )
+  );
+
+  metil_player->position.y = (
+    metil_player->position.y + (
+      movement.y *
+      metil_player->speed_movement
+    ) + (
+      metil_player->velocity.y *
+      speed_delta
+    )
+  );
+
+  metil_player->position.z = (
+    metil_player->position.z + (
+      movement.z *
+      metil_player->speed_movement
+    )
+  );
+
+  if (
+    metil_player->position.y > metil_player->position_y_floor
+  ) {
+    metil_player->velocity.y = (
+      metil_player->velocity.y -
+      speed_original *
+      speed_delta *
+      5.0f
+    );
+  }
+
+  if (
+    metil_player->position.y < metil_player->position_y_floor
+  ) {
+    metil_player->position.y = (
+      metil_player->position_y_floor
+    );
+
+    metil_player->velocity.y = 0.0f;
+  }
+
+  metil_player->speed_movement = (
+    speed_original
+  );
+}

--- a/sources/scenes/scene_intro_forest.m
+++ b/sources/scenes/scene_intro_forest.m
@@ -1,6 +1,8 @@
 #include <scenes/scene_intro_forest.h>
 
 #include <audio/io_proc_data.h>
+#include <data/data_zoe.h>
+#include <input/input_movement.h>
 #include <model/model_player.h>
 #include <object/object_ground.h>
 #include <object/object_tree.h>
@@ -10,12 +12,15 @@
 #include <metil_audio/metil_audio_io_proc.h>
 #include <metil_audio/metil_audio_io_proc_data.h>
 #include <metil_collision/metil_collision_uncollide/metil_collision_uncollide_circular.h>
+#include <metil_group.h>
 #include <metil_object/metil_object.h>
 #include <metil_object/metil_object_buffer.h>
 #include <metil_paths/metil_paths.h>
 #include <metil_rendering/metil_camera/metil_camera_mode.h>
 #include <metil_rendering/metil_renderer_interface.h>
 #include <metil_scenes/metil_scene.h>
+
+#include <clic3_memory.h>
 
 #include <rand_clean.h>
 #include <rand_functions.h>
@@ -37,6 +42,10 @@ void scene_intro_forest_initialize(
   struct metil* metil,
   struct metil_scene* scene
 ) {
+  struct data_zoe* data_zoe = (
+    metil->data
+  );
+
   metil->rendering_properties.brightness = (
     metil->configuration.rendering_properties.brightness
   );
@@ -57,13 +66,24 @@ void scene_intro_forest_initialize(
   metil_scene_initialize_with_renderables(
     metil,
     scene,
-    503
+    scene_intro_forest_length_renderables
   );
 
   scene->player.rotation.x = -0.3f;
+  scene->player.data = (
+    &data_zoe->player
+  );
 
-  scene->data = malloc(
-    sizeof(struct scene_intro_forest_data)
+  scene->player.poll_input = (
+    zoe_input_movement
+  );
+
+  scene->data = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct scene_intro_forest_data
+      )
+    )
   );
 
   struct scene_intro_forest_data* data_scene = (
@@ -93,11 +113,39 @@ void scene_intro_forest_initialize(
     index_renderable < scene->length_renderables;
     ++index_renderable
   ) {
-    metil_renderable_initialize_at_index(
-      scene->renderables,
-      index_renderable,
-      metil_renderable_type_object
-    );
+    switch (
+      index_renderable
+    ) {
+      case scene_intro_forest_index_renderable_player:
+      case scene_intro_forest_index_renderable_player_mirror: {
+        metil_renderable_initialize_at_index(
+          scene->renderables,
+          index_renderable,
+          metil_renderable_type_model
+        );
+        break;
+      }
+      case scene_intro_forest_index_renderable_group_trees: {
+        metil_renderable_initialize_at_index(
+          scene->renderables,
+          index_renderable,
+          metil_renderable_type_group
+        );
+
+        break;
+      }
+      case scene_intro_forest_index_renderable_ground:
+      default: {
+        metil_renderable_initialize_at_index(
+          scene->renderables,
+          index_renderable,
+          metil_renderable_type_object
+        );
+
+        break;
+      }
+    }
+    
   }
 
   scene->length_textures = 3;
@@ -169,7 +217,7 @@ void scene_intro_forest_initialize(
 
   struct metil_model* metil_model_player = (
     scene->renderables[
-      0
+      scene_intro_forest_index_renderable_player
     ].renderable
   );
 
@@ -204,13 +252,13 @@ void scene_intro_forest_initialize(
 
   struct metil_model* metil_model_player_mirror = (
     scene->renderables[
-      1
+      scene_intro_forest_index_renderable_player_mirror
     ].renderable
   );
 
   zoe_model_player_initialize(
     metil,
-    metil_model_player,
+    metil_model_player_mirror,
     scene->textures[
       textures_scene_intro_forest_player
     ],
@@ -219,7 +267,7 @@ void scene_intro_forest_initialize(
 
   struct metil_object* metil_object_ground = (
     scene->renderables[
-      2
+      scene_intro_forest_index_renderable_ground
     ].renderable
   );
 
@@ -239,6 +287,18 @@ void scene_intro_forest_initialize(
     metil->renderer_interface.metal_device
   );
 
+  struct metil_group* metil_group_trees = (
+    scene->renderables[
+      scene_intro_forest_index_renderable_group_trees
+    ].renderable
+  );
+
+  metil_group_add_length_initialize(
+    metil_group_trees,
+    scene_intro_forest_length_group_trees_renderables,
+    metil_renderable_type_object
+  );
+
   struct rand_parameters rand_parameters;
   struct rand_source rand_source;
   struct rand_result rand_result;
@@ -247,7 +307,7 @@ void scene_intro_forest_initialize(
     &rand_parameters,
     &rand_result,
     &rand_source, (
-      (scene->length_renderables - 3) *
+      metil_group_trees->length *
       4
     ),
     rand_mode_bytes,
@@ -263,18 +323,18 @@ void scene_intro_forest_initialize(
   unsigned int offset_byte = 0;
 
   for (
-    unsigned short int index_renderable = 3;
-    index_renderable < scene->length_renderables;
+    unsigned short int index_renderable = 0;
+    index_renderable < metil_group_trees->length;
     ++index_renderable
   ) {
     offset_byte = (
-      (index_renderable - 3) * 4
+      index_renderable * 4
     );
 
     struct metil_object* object = (
-      scene->renderables[
+      metil_group_trees->renderables[
         index_renderable
-      ].renderable
+      ]->renderable
     );
 
     zoe_object_tree_initialize(
@@ -293,8 +353,16 @@ void scene_intro_forest_initialize(
     object->position.x = (
       -(object->mesh.size.x / 2.0f) + (
         (((float)((
-          rand_result.bytes[offset_byte] *
-          rand_result.bytes[offset_byte + 2]
+          (
+            rand_result.bytes[offset_byte] %
+            0xfe +
+            0x01
+          ) *
+          (
+            rand_result.bytes[offset_byte + 2] %
+            0xfe +
+            0x01
+          )
         ) % 10000) / 5000.0f) - 1.0f) * 0.7f *
         (object->mesh.size.x - (
           metil_object_ground->mesh.size.x / 2.0f
@@ -305,8 +373,16 @@ void scene_intro_forest_initialize(
     object->position.z = (
       -(object->mesh.size.z / 2.0f) + (
         (((float)((
-          rand_result.bytes[offset_byte + 1] *
-          rand_result.bytes[offset_byte + 3]
+          (
+            rand_result.bytes[offset_byte + 1]  %
+            0xfe +
+            0x01
+          ) *
+          (
+            rand_result.bytes[offset_byte + 3] %
+            0xfe +
+            0x01
+          )
         ) % 10000) / 5000.0f) - 1.0f) * 0.7f *
         (metil_object_ground->mesh.size.z - (
           metil_object_ground->mesh.size.z / 2.0f
@@ -330,15 +406,21 @@ void scene_intro_forest_poll(
     scene
   );
 
+  struct metil_group* metil_group_trees = (
+    scene->renderables[
+      scene_intro_forest_index_renderable_group_trees
+    ].renderable
+  );
+
   for (
-    unsigned short int index_renderable = 3;
-    index_renderable < scene->length_renderables;
+    unsigned short int index_renderable = 0;
+    index_renderable < metil_group_trees->length;
     ++index_renderable
   ) {
     struct metil_object* metil_object_tree = (
-      scene->renderables[
+      metil_group_trees->renderables[
         index_renderable
-      ].renderable
+      ]->renderable
     );
 
     metil_collision_player_object_uncollide_circular_xz(

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -2,7 +2,10 @@
 
 #include <audio/io_proc_data.h>
 #include <calculations/hill_y_value.h>
+#include <data/data_player.h>
+#include <data/data_zoe.h>
 #include <group/group_text_with_backing.h>
+#include <input/input_movement.h>
 #include <mesh/mesh_hill.h>
 #include <model/model_player.h>
 #include <object/object_hill.h>
@@ -23,6 +26,9 @@
 #include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_rendering/metil_renderer_vertex_index_parameter.h>
 #include <metil_scenes/metil_scene.h>
+#include <metil_scenes/metil_scene_controller.h>
+
+#include <clic3_memory.h>
 
 #include <math_c_absolute.h>
 #include <math_c_maximum.h>
@@ -50,6 +56,10 @@ void scene_intro_hill_initialize(
   struct metil* metil,
   struct metil_scene* scene
 ) {
+  struct data_zoe* data_zoe = (
+    metil->data
+  );
+
   metil->rendering_properties.brightness = (
     metil->configuration.rendering_properties.brightness
   );
@@ -73,11 +83,21 @@ void scene_intro_hill_initialize(
     scene_intro_hill_length_renderables
   );
 
+  scene->player.poll_input = (
+    zoe_input_movement
+  );
+
+  scene->player.data = (
+    &data_zoe->player
+  );
+
   scene->player.rotation.x = -0.3f;
 
-  scene->data = malloc(
-    sizeof(
-      struct scene_intro_hill_data
+  scene->data = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct scene_intro_hill_data
+      )
     )
   );
 
@@ -382,9 +402,17 @@ void scene_intro_hill_poll(
   struct metil* metil,
   struct metil_scene* scene
 ) {
+  struct scene_intro_hill_data* scene_intro_hill_data = (
+    scene->data
+  );
+
   metil_scene_poll_default(
     metil,
     scene
+  );
+
+  struct data_player* data_player = (
+    scene->player.data
   );
 
   struct math_c_vector2_float position_player_bounds_minimum = {
@@ -546,6 +574,25 @@ void scene_intro_hill_poll(
         25.0f,
         20.0f
       );
+
+      if (
+        index_tree == 0 &&
+        metil_group_text_tree->visible != 0 &&
+        data_player->actions & data_player_action_select
+      ) {
+        data_player->actions = (
+          data_player->actions ^
+          data_player_action_select
+        );
+
+        metil_scene_controller_scene_change(
+          metil,
+          metil->scene_controller,
+          scene_id_intro_forest
+        );
+
+        return;
+      }
     } else {
       metil_group_text_tree->visible = 0;
     }

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -23,6 +23,8 @@
 #include <metil_termination/metil_termination.h>
 #endif
 
+#include <clic3_memory.h>
+
 #include <rand_clean.h>
 #include <rand_functions.h>
 #include <rand_initialize.h>
@@ -53,8 +55,12 @@ void scene_menu_main_initialize(
     5
   );
 
-  scene->data = malloc(
-    sizeof(struct scene_menu_main_data)
+  scene->data = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct scene_menu_main_data
+      )
+    )
   );
 
   struct scene_menu_main_data* data_scene = (
@@ -344,6 +350,8 @@ void scene_menu_main_poll(
         metil->scene_controller,
         scene_id_intro_hill
       );
+
+      return;
     } else {
       float brightness = (
         (float) (scene_menu_main_time_scene_transition - time_delta) /

--- a/sources/zoe.m
+++ b/sources/zoe.m
@@ -1,5 +1,6 @@
 #include <zoe.h>
 
+#include <data/data_zoe.h>
 #include <scenes/scene_id.h>
 #include <scenes/scene_intro_forest.h>
 #include <scenes/scene_intro_hill.h>
@@ -14,6 +15,8 @@
 #include <metil_object/metil_object_text.h>
 #include <metil_rendering/metil_renderer_interface.h>
 #include <metil_scenes/metil_scene_controller.h>
+
+#include <clic3_memory.h>
 
 #if target_os_ios
 char* zoe_executable_path = (
@@ -207,6 +210,22 @@ void zoe_renderer_on_initialize(
   metil->rendering_properties.color_clear.z = 0.0649f;
   metil->rendering_properties.color_clear.w = 1.0f;
 
+  metil->data = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct data_zoe
+      )
+    )
+  );
+
+  data_zoe_initialize(
+    metil->data
+  );
+
+  metil->destroy = (
+    zoe_destroy
+  );
+
   struct metil_scene_controller* metil_scene_controller = (
     metil->scene_controller
   );
@@ -265,4 +284,12 @@ void zoe_on_scene_change(
       );
       break;
   }
+}
+
+void zoe_destroy(
+  struct metil* metil
+) {
+  clic3_memory_free_raw(
+    metil->data
+  );
 }


### PR DESCRIPTION
adds a quick scene change in

need to add an input prompt and also a loading/splash screen

- `data/data_player`:add
- - will be used for player specific things such as actions
- `data/data_zoe`:add
- - will be used for keeping track of overall game state (things like currency, stats, etc)
- fixes `scene_intro_forest` rendering
- - renderables were mislabled as objects when they should have been models
- - groups trees together under a single `metil_group`
- - this scene wasn't accessible before so this shouldn't have been a problem
- adds zoe specific input polling