### PR TITLE
[dev] add_loading_module

### DIFF
--- a/include/scenes/scene_loading.h
+++ b/include/scenes/scene_loading.h
@@ -1,0 +1,36 @@
+#ifndef __zoe_scenes_scene_loading_h
+#define __zoe_scenes_scene_loading_h
+
+#include <zoe_loading_map.h>
+
+#include <metil.h>
+#include <metil_scenes/metil_scene.h>
+
+struct data_scene_loading {
+  unsigned char id_scene;
+
+  struct zoe_loading_map loading_map;
+
+  struct metil_scene scene;
+
+  void* _Nullable data;
+};
+
+void scene_loading_initialize(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned char
+);
+
+void scene_loading_poll(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull
+);
+
+void scene_loading_finished(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  struct data_scene_loading* _Nonnull
+);
+
+#endif

--- a/include/zoe_loading_map.h
+++ b/include/zoe_loading_map.h
@@ -1,0 +1,72 @@
+#ifndef __zoe_loading_map_h
+#define __zoe_loading_map_h
+
+#include <metil.h>
+#include <metil_scenes/metil_scene.h>
+
+typedef unsigned char (*zoe_scene_loading_loading_initialize_function)(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned char,
+  void* _Nullable
+);
+
+typedef unsigned char (*zoe_scene_loading_loading_poll_function)(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned char,
+  void* _Nullable
+);
+
+typedef void (*zoe_scene_loading_loading_finished_function)(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned char,
+  void* _Nullable
+);
+
+struct zoe_loading_map {
+  zoe_scene_loading_loading_initialize_function _Nonnull initialize;
+  zoe_scene_loading_loading_poll_function _Nonnull poll;
+  zoe_scene_loading_loading_finished_function _Nonnull finished;
+};
+
+void zoe_loading_map_initialize(
+  struct zoe_loading_map* _Nonnull,
+  unsigned char
+);
+
+zoe_scene_loading_loading_initialize_function _Nonnull zoe_loading_map_initialize_function_get(
+  unsigned char
+);
+
+zoe_scene_loading_loading_poll_function _Nonnull zoe_loading_map_poll_function_get(
+  unsigned char
+);
+
+zoe_scene_loading_loading_finished_function _Nonnull zoe_loading_map_finished_function_get(
+  unsigned char
+);
+
+unsigned char zoe_scene_loading_loading_initialize_function_no_load(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned char,
+  void* _Nullable
+);
+
+unsigned char zoe_scene_loading_loading_poll_function_no_load(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned char,
+  void* _Nullable
+);
+
+void zoe_scene_loading_loading_finished_function_no_load(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned char,
+  void* _Nullable
+);
+
+#endif

--- a/sources/scenes/scene_loading.m
+++ b/sources/scenes/scene_loading.m
@@ -1,0 +1,130 @@
+#include <scenes/scene_loading.h>
+
+#include <zoe_loading_map.h>
+
+#include <metil.h>
+#include <metil_scenes/metil_scene.h>
+
+#include <clic3_bytes.h>
+#include <clic3_memory.h>
+
+void scene_loading_initialize(
+  struct metil* metil,
+  struct metil_scene* metil_scene_loading,
+  unsigned char id_scene
+) {
+  static struct data_scene_loading* data_scene_loading;
+  
+  data_scene_loading = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct data_scene_loading
+      )
+    )
+  );
+
+  data_scene_loading->data = 0;
+
+  data_scene_loading->id_scene = (
+    id_scene
+  );
+  
+  zoe_loading_map_initialize(
+    &data_scene_loading->loading_map,
+    data_scene_loading->id_scene
+  );
+
+  unsigned char initialized = (
+    data_scene_loading->loading_map.initialize(
+      metil,
+      &data_scene_loading->scene,
+      data_scene_loading->id_scene,
+      &data_scene_loading->data
+    )
+  );
+
+  if (
+    initialized != 0
+  ) {
+    scene_loading_finished(
+      metil,
+      metil_scene_loading,
+      data_scene_loading
+    );
+
+    return;
+  }
+  
+  metil_scene_initialize_with_renderables(
+    metil,
+    metil_scene_loading,
+    0
+  );
+
+  metil_scene_loading->data = (
+    data_scene_loading
+  );
+
+  metil_scene_loading->poll = (
+    scene_loading_poll
+  );
+}
+
+void scene_loading_poll(
+  struct metil* metil,
+  struct metil_scene* metil_scene_loading
+) {
+  struct data_scene_loading* data_scene_loading = (
+    metil_scene_loading->data
+  );
+
+  unsigned char initialized = (
+    data_scene_loading->loading_map.poll(
+      metil,
+      &data_scene_loading->scene,
+      data_scene_loading->id_scene,
+      &data_scene_loading->data
+    )
+  );
+
+  if (
+    initialized != 0
+  ) {
+    scene_loading_finished(
+      metil,
+      metil_scene_loading,
+      data_scene_loading
+    );
+
+    return;
+  }
+}
+
+void scene_loading_finished(
+  struct metil* metil,
+  struct metil_scene* metil_scene_loading,
+  struct data_scene_loading* data_scene_loading
+) {
+  clic3_bytes_copy(
+    metil_scene_loading,
+    &data_scene_loading->scene,
+    sizeof(
+      struct metil_scene
+    )
+  );
+
+  data_scene_loading->loading_map.finished(
+    metil,
+    metil_scene_loading,
+    data_scene_loading->id_scene,
+    &data_scene_loading->data
+  );
+
+  clic3_memory_free(
+    data_scene_loading->data
+  );
+
+  clic3_memory_free_raw(
+    data_scene_loading
+  );
+}

--- a/sources/scenes/scene_loading.m
+++ b/sources/scenes/scene_loading.m
@@ -90,6 +90,21 @@ void scene_loading_poll(
   if (
     initialized != 0
   ) {
+    struct data_scene_loading* data_scene_loading = (
+      metil_scene_loading->data
+    );
+
+    metil_scene_loading->data = 0;
+
+    metil_scene_loading->destroy(
+      metil,
+      metil_scene_loading
+    );
+
+    metil_scene_loading->data = (
+      data_scene_loading
+    );
+
     scene_loading_finished(
       metil,
       metil_scene_loading,

--- a/sources/zoe.m
+++ b/sources/zoe.m
@@ -2,8 +2,7 @@
 
 #include <data/data_zoe.h>
 #include <scenes/scene_id.h>
-#include <scenes/scene_intro_forest.h>
-#include <scenes/scene_intro_hill.h>
+#include <scenes/scene_loading.h>
 #include <scenes/scene_menu_main.h>
 #include <zoe_pipeline_index.h>
 
@@ -260,30 +259,11 @@ void zoe_on_scene_change(
     metil_scene
   );
 
-  switch (
+  scene_loading_initialize(
+    metil,
+    metil_scene,
     id_scene
-  ) {
-    case scene_id_intro_forest:
-      scene_intro_forest_initialize(
-        metil,
-        metil_scene
-      );
-      break;
-    case scene_id_intro_hill:
-      scene_intro_hill_initialize(
-        metil,
-        metil_scene
-      );
-      break;
-    case scene_id_menu_main:
-    case scene_id_unknown:
-    default:
-      scene_menu_main_initialize(
-        metil,
-        metil_scene
-      );
-      break;
-  }
+  );
 }
 
 void zoe_destroy(

--- a/sources/zoe_loading_map.m
+++ b/sources/zoe_loading_map.m
@@ -1,0 +1,133 @@
+#include <zoe_loading_map.h>
+
+#include <scenes/scene_id.h>
+#include <scenes/scene_intro_forest.h>
+#include <scenes/scene_intro_hill.h>
+#include <scenes/scene_menu_main.h>
+
+void zoe_loading_map_initialize(
+  struct zoe_loading_map* zoe_loading_map,
+  unsigned char id_scene
+) {
+  zoe_loading_map->initialize = (
+    zoe_loading_map_initialize_function_get(
+      id_scene
+    )
+  );
+
+  zoe_loading_map->poll = (
+    zoe_loading_map_poll_function_get(
+      id_scene
+    )
+  );
+
+  zoe_loading_map->finished = (
+    zoe_loading_map_finished_function_get(
+      id_scene
+    )
+  );
+}
+
+zoe_scene_loading_loading_initialize_function zoe_loading_map_initialize_function_get(
+  unsigned char id_scene
+) {
+  switch (
+    id_scene
+  ) {
+    case scene_id_intro_forest:
+    case scene_id_intro_hill:
+    case scene_id_menu_main:
+    case scene_id_unknown:
+    default: {
+      return (
+        zoe_scene_loading_loading_initialize_function_no_load
+      );
+    }
+  }
+}
+
+zoe_scene_loading_loading_poll_function zoe_loading_map_poll_function_get(
+  unsigned char id_scene
+) {
+  switch (
+    id_scene
+  ) {
+    case scene_id_intro_forest:
+    case scene_id_intro_hill:
+    case scene_id_menu_main:
+    case scene_id_unknown:
+    default: {
+      return (
+        zoe_scene_loading_loading_poll_function_no_load
+      );
+    }
+  }
+}
+
+zoe_scene_loading_loading_finished_function zoe_loading_map_finished_function_get(
+  unsigned char id_scene
+) {
+  switch (
+    id_scene
+  ) {
+    case scene_id_intro_forest:
+    case scene_id_intro_hill:
+    case scene_id_menu_main:
+    case scene_id_unknown:
+    default: {
+      return (
+        zoe_scene_loading_loading_finished_function_no_load
+      );
+    }
+  }
+}
+
+unsigned char zoe_scene_loading_loading_initialize_function_no_load(
+  struct metil* metil,
+  struct metil_scene* metil_scene,
+  unsigned char id_scene,
+  void* data
+) {
+  return 1;
+}
+
+unsigned char zoe_scene_loading_loading_poll_function_no_load(
+  struct metil* metil,
+  struct metil_scene* metil_scene,
+  unsigned char id_scene,
+  void* data
+) {
+  return 1;
+}
+
+void zoe_scene_loading_loading_finished_function_no_load(
+  struct metil* metil,
+  struct metil_scene* metil_scene,
+  unsigned char id_scene,
+  void* data
+) {
+  switch (
+    id_scene
+  ) {
+    case scene_id_intro_forest:
+      scene_intro_forest_initialize(
+        metil,
+        metil_scene
+      );
+      break;
+    case scene_id_intro_hill:
+      scene_intro_hill_initialize(
+        metil,
+        metil_scene
+      );
+      break;
+    case scene_id_menu_main:
+    case scene_id_unknown:
+    default:
+      scene_menu_main_initialize(
+        metil,
+        metil_scene
+      );
+      break;
+  }
+}


### PR DESCRIPTION
this will be used for setting loading screens between scene transitions

all scene changes will pass through this

a look up occurs to see if the scene has loading functionality and if it does it will render a (currently blank) scene until the loading poll returns a non-zero value otherwise it will initialize the scene instantly.