### PR TITLE
[dev] add_loading_module::Destroy renderables while preserving data loader

### DIFF
--- a/sources/scenes/scene_loading.m
+++ b/sources/scenes/scene_loading.m
@@ -90,6 +90,21 @@ void scene_loading_poll(
   if (
     initialized != 0
   ) {
+    struct data_scene_loading* data_scene_loading = (
+      metil_scene_loading->data
+    );
+
+    metil_scene_loading->data = 0;
+
+    metil_scene_loading->destroy(
+      metil,
+      metil_scene_loading
+    );
+
+    metil_scene_loading->data = (
+      data_scene_loading
+    );
+
     scene_loading_finished(
       metil,
       metil_scene_loading,


### PR DESCRIPTION
destroy the scene created by the loader while preserving the data property to be freed within the finished function

the scene is only initialized fully if the initialize function returns a value of zero which is why this function is only called within the poll check