### PR TITLE
[dev] Zoe loading map change positions

### DIFF
--- a/sources/zoe_loading_map.m
+++ b/sources/zoe_loading_map.m
@@ -88,24 +88,6 @@ unsigned char zoe_scene_loading_loading_initialize_function_no_load(
   unsigned char id_scene,
   void* data
 ) {
-  return 1;
-}
-
-unsigned char zoe_scene_loading_loading_poll_function_no_load(
-  struct metil* metil,
-  struct metil_scene* metil_scene,
-  unsigned char id_scene,
-  void* data
-) {
-  return 1;
-}
-
-void zoe_scene_loading_loading_finished_function_no_load(
-  struct metil* metil,
-  struct metil_scene* metil_scene,
-  unsigned char id_scene,
-  void* data
-) {
   switch (
     id_scene
   ) {
@@ -130,4 +112,22 @@ void zoe_scene_loading_loading_finished_function_no_load(
       );
       break;
   }
+
+  return 1;
 }
+
+unsigned char zoe_scene_loading_loading_poll_function_no_load(
+  struct metil* metil,
+  struct metil_scene* metil_scene,
+  unsigned char id_scene,
+  void* data
+) {
+  return 1;
+}
+
+void zoe_scene_loading_loading_finished_function_no_load(
+  struct metil* metil,
+  struct metil_scene* metil_scene,
+  unsigned char id_scene,
+  void* data
+) {}


### PR DESCRIPTION
moving this to the initialize function since it makes more sense there and doesn't bypass the `clic3_bytes_copy` function call.

works either way though, but, this allows the finished function to be used as a "don't need a finish function" for scenes which dont need to implement one, in which case the name `zoe_scene_loading_loading_finished_function_no_load` may be a bit in-apt due to the `no_load` part, but who cares, it's a no-op function regardless so it works just the same regardless of the name.