### PR TITLE
[dev] threaded forest renderables

### DIFF
--- a/include/scenes/scene_intro_forest/scene_intro_forest.h
+++ b/include/scenes/scene_intro_forest/scene_intro_forest.h
@@ -4,6 +4,7 @@
 #include <audio/io_proc_data.h>
 #include <zoe_loading_threads.h>
 
+#include <metil_group.h>
 #include <metil_scenes/metil_scene.h>
 #include <metil_rendering/metil_renderer_interface.h>
 
@@ -34,7 +35,18 @@ struct scene_intro_forest_data {
   struct io_proc_data* _Nonnull io_proc_data;
 };
 
+struct scene_intro_forest_tree_thread_data {
+  struct metil_group* _Nonnull group;
+  struct math_c_vector3_float* _Nonnull size_bounds;
+  unsigned int offset;
+  unsigned int length;
+};
+
 void scene_intro_forest_initialize(
+  struct zoe_loading_threads_data* _Nonnull
+);
+
+void zoe_scene_intro_forest_threaded_trees_initialization(
   struct zoe_loading_threads_data* _Nonnull
 );
 

--- a/include/zoe_loading_threads.h
+++ b/include/zoe_loading_threads.h
@@ -6,7 +6,10 @@
 
 #include <pthread.h>
 
+struct zoe_loading_threads;
+
 struct zoe_loading_threads_data {
+  struct zoe_loading_threads* loading_threads;
   struct metil* metil;
   struct metil_scene* scene;
   unsigned char id_scene;
@@ -26,7 +29,7 @@ struct zoe_loading_threads_passthrough_data {
 
 struct zoe_loading_threads {
   pthread_t* threads;
-  struct zoe_loading_threads_data* data;
+  struct zoe_loading_threads_data** data;
   unsigned char length;
 
   struct metil* metil;

--- a/include/zoe_pipeline_index.h
+++ b/include/zoe_pipeline_index.h
@@ -3,6 +3,7 @@
 
 extern unsigned short int zoe_pipeline_index_ground;
 extern unsigned short int zoe_pipeline_index_hill;
+extern unsigned short int zoe_pipeline_index_loading_screen;
 extern unsigned short int zoe_pipeline_index_player_arm;
 extern unsigned short int zoe_pipeline_index_player_body;
 extern unsigned short int zoe_pipeline_index_player_head;

--- a/metal/zoe_loading_screen.metal
+++ b/metal/zoe_loading_screen.metal
@@ -1,0 +1,98 @@
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+#include <metal_stdlib>
+
+struct data_vertex {
+  float4 position [[position]];
+  float4 color;
+  float brightness;
+};
+
+[[vertex]] struct data_vertex zoe_loading_screen_vertex(
+  const device simd_float4* positions [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    positions[
+      id_vertex
+    ]
+  );
+
+  data_vertex.brightness = (
+    data_frame->brightness
+  );
+
+  float progress = (
+    (float) data_object->noise /
+    10000.0f
+  );
+
+  data_vertex.color.x = (
+    (
+      progress < 0.3f
+      ? progress
+      : 0.0f
+    ) / 0.3f
+  );
+
+  data_vertex.color.y = (
+    (
+      (progress < 0.6f)
+      ? progress - 0.3f
+      : 0.0f
+    ) / 0.3f
+  );
+
+  data_vertex.color.z = (
+    (
+      (progress >= 0.6f)
+      ? progress - 0.6f
+      : 0.0f
+    ) / 0.4f
+  );
+
+  data_vertex.color.w = (
+    1.0f
+  );
+
+  return data_vertex;
+}
+
+[[fragment]] float4 zoe_loading_screen_fragment(
+  struct data_vertex data_vertex [[stage_in]]
+) {
+  return float4(
+    (
+      data_vertex.color.x *
+      data_vertex.brightness
+    ),
+    (
+      data_vertex.color.y *
+      data_vertex.brightness
+    ),
+    (
+      data_vertex.color.z *
+      data_vertex.brightness
+    ),
+    data_vertex.color.w
+  );
+}

--- a/sources/scenes/scene_intro_forest/scene_intro_forest.m
+++ b/sources/scenes/scene_intro_forest/scene_intro_forest.m
@@ -37,8 +37,6 @@
 #include <CoreAudio/CoreAudio.h>
 #endif
 
-#include <stdlib.h>
-
 void scene_intro_forest_initialize(
   struct zoe_loading_threads_data* zoe_loading_threads_data
 ) {
@@ -567,11 +565,17 @@ void zoe_scene_intro_forest_threaded_trees_initialization(
       )
     );
 
+    metil_object_tree->index_pipeline_render = (
+      zoe_pipeline_index_tree
+    );
+
     zoe_loading_threads_progress_increase(
       zoe_loading_threads_data,
       (
-        index_renderable /
-        metil_group_trees->length *
+        (
+          1.0f /
+          (float) metil_group_trees->length
+        ) *
         0.55f
       )
     );

--- a/sources/scenes/scene_intro_forest/scene_intro_forest.m
+++ b/sources/scenes/scene_intro_forest/scene_intro_forest.m
@@ -320,10 +320,137 @@ void scene_intro_forest_initialize(
     ].renderable
   );
 
-  metil_group_add_length_initialize(
+  metil_group_allocate_length(
     metil_group_trees,
     scene_intro_forest_length_group_trees_renderables,
     metil_renderable_type_object
+  );
+
+  unsigned short int length_renderables_thread = (
+    metil_group_trees->length /
+    metil->system_information.cores_cpu
+  );
+
+  for (
+    unsigned char index_thread = 0;
+    index_thread < metil->system_information.cores_cpu;
+    ++index_thread
+  ) {
+    unsigned short int offset = (
+      length_renderables_thread *
+      index_thread
+    );
+
+    unsigned short int length;
+
+    if (
+      offset >= metil_group_trees->length
+    ) {
+      break;
+    }
+
+    if (
+      index_thread == (
+        metil->system_information.cores_cpu -
+        1
+      )
+    ) {
+      length = (
+        metil_group_trees->length -
+        offset
+      );
+    } else {
+      length = (
+        length_renderables_thread
+      );
+    }
+
+    if (
+      (
+        offset +
+        length
+      ) > metil_group_trees->length
+    ) {
+      length = (
+        metil_group_trees->length -
+        offset
+      );
+    }
+
+    static struct scene_intro_forest_tree_thread_data* scene_intro_forest_tree_thread_data;
+
+    scene_intro_forest_tree_thread_data = (
+      clic3_memory_allocate_raw(
+        sizeof(
+          struct scene_intro_forest_tree_thread_data
+        )
+      )
+    );
+
+    scene_intro_forest_tree_thread_data->group = (
+      metil_group_trees
+    );
+
+    scene_intro_forest_tree_thread_data->size_bounds = (
+      &metil_object_ground->mesh.size
+    );
+
+    scene_intro_forest_tree_thread_data->offset = (
+      offset
+    );
+
+    scene_intro_forest_tree_thread_data->length = (
+      length
+    );
+
+    zoe_loading_threads_spawn(
+      zoe_loading_threads_data->loading_threads,
+      zoe_scene_intro_forest_threaded_trees_initialization,
+      scene_intro_forest_tree_thread_data
+    );
+  }
+
+  for (
+    unsigned char index_thread = 0;
+    index_thread < metil->system_information.cores_cpu;
+    ++index_thread
+  ) {
+    pthread_join(
+      zoe_loading_threads_data->loading_threads->threads[
+        index_thread +
+        1
+      ],
+      0
+    );
+  }
+
+  zoe_loading_threads_progress_set(
+    zoe_loading_threads_data,
+    1.0f
+  );
+}
+
+void zoe_scene_intro_forest_threaded_trees_initialization(
+  struct zoe_loading_threads_data* zoe_loading_threads_data
+) {
+  struct metil* metil = (
+    zoe_loading_threads_data->metil
+  );
+
+  struct metil_scene* scene = (
+    zoe_loading_threads_data->scene
+  );
+
+  struct scene_intro_forest_tree_thread_data* scene_intro_forest_tree_thread_data = (
+    zoe_loading_threads_data->data
+  );
+
+  struct metil_group* metil_group_trees = (
+    scene_intro_forest_tree_thread_data->group
+  );
+
+  struct math_c_vector3_float* size_bounds = (
+    scene_intro_forest_tree_thread_data->size_bounds
   );
 
   struct rand_parameters rand_parameters;
@@ -333,8 +460,9 @@ void scene_intro_forest_initialize(
   rand_initialize(
     &rand_parameters,
     &rand_result,
-    &rand_source, (
-      metil_group_trees->length *
+    &rand_source,
+    (
+      scene_intro_forest_tree_thread_data->length *
       4
     ),
     rand_mode_bytes,
@@ -347,37 +475,30 @@ void scene_intro_forest_initialize(
     &rand_parameters
   );
 
-  unsigned int offset_byte = 0;
-
   for (
-    unsigned short int index_renderable = 0;
-    index_renderable < metil_group_trees->length;
+    unsigned int index_renderable = scene_intro_forest_tree_thread_data->offset;
+    index_renderable < (
+      scene_intro_forest_tree_thread_data->offset +
+      scene_intro_forest_tree_thread_data->length
+    );
     ++index_renderable
   ) {
-    zoe_loading_threads_progress_set(
-      zoe_loading_threads_data,
-      (
-        0.4f +
-        (
-          0.5f *
-          (float) index_renderable /
-          (float) metil_group_trees->length
-        )
-      )
-    );
-
-    offset_byte = (
-      index_renderable * 4
-    );
-
-    struct metil_object* object = (
+    struct metil_object* metil_object_tree = (
       metil_group_trees->renderables[
         index_renderable
       ]->renderable
     );
 
+    metil_object_initialize(
+      metil_object_tree
+    );
+
+    unsigned short int offset_byte = (
+      index_renderable * 4
+    );
+
     zoe_object_tree_initialize(
-      object,
+      metil_object_tree,
       (void*) 0,
       (struct math_c_vector2_float) {
         .x = 5.0f,
@@ -389,43 +510,69 @@ void scene_intro_forest_initialize(
       metil->renderer_interface.metal_device
     );
     
-    object->position.x = (
-      -(object->mesh.size.x / 2.0f) + (
+    metil_object_tree->position.x = (
+      -(metil_object_tree->mesh.size.x / 2.0f) + (
         (((float)((
           (
-            rand_result.bytes[offset_byte] %
+            rand_result.bytes[
+              offset_byte
+            ] %
             0xfe +
             0x01
           ) *
           (
-            rand_result.bytes[offset_byte + 2] %
+            rand_result.bytes[
+              offset_byte +
+              2
+            ] %
             0xfe +
             0x01
           )
         ) % 10000) / 5000.0f) - 1.0f) * 0.7f *
-        (object->mesh.size.x - (
-          metil_object_ground->mesh.size.x / 2.0f
-        ))
+        (
+          metil_object_tree->mesh.size.x - (
+            size_bounds->x /
+            2.0f
+          )
+        )
       )
     );
 
-    object->position.z = (
-      -(object->mesh.size.z / 2.0f) + (
+    metil_object_tree->position.z = (
+      -(metil_object_tree->mesh.size.z / 2.0f) + (
         (((float)((
           (
-            rand_result.bytes[offset_byte + 1]  %
+            rand_result.bytes[
+              offset_byte +
+              1
+            ]  %
             0xfe +
             0x01
           ) *
           (
-            rand_result.bytes[offset_byte + 3] %
+            rand_result.bytes[
+              offset_byte +
+              3
+            ] %
             0xfe +
             0x01
           )
         ) % 10000) / 5000.0f) - 1.0f) * 0.7f *
-        (metil_object_ground->mesh.size.z - (
-          metil_object_ground->mesh.size.z / 2.0f
-        ))
+        (
+          size_bounds->z - (
+            size_bounds->z /
+            2.0f
+          )
+        )
+      )
+    );
+
+    zoe_loading_threads_progress_increase(
+      zoe_loading_threads_data,
+      (
+        index_renderable /
+        metil_group_trees->length *
+        0.55f
       )
     );
   }
@@ -433,11 +580,6 @@ void scene_intro_forest_initialize(
   rand_clean(
     &rand_result,
     &rand_source
-  );
-
-  zoe_loading_threads_progress_set(
-    zoe_loading_threads_data,
-    1.0f
   );
 }
 
@@ -473,7 +615,6 @@ void scene_intro_forest_poll(
     );
   }
 }
-
 
 void scene_intro_forest_destroy(
   struct metil* metil,

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -411,8 +411,6 @@ void scene_intro_hill_poll(
     scene
   );
 
-  scene->player.speed_movement = 10000.0f;
-
   struct data_player* data_player = (
     scene->player.data
   );

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -411,6 +411,8 @@ void scene_intro_hill_poll(
     scene
   );
 
+  scene->player.speed_movement = 10000.0f;
+
   struct data_player* data_player = (
     scene->player.data
   );

--- a/sources/scenes/scene_loading.m
+++ b/sources/scenes/scene_loading.m
@@ -1,12 +1,18 @@
 #include <scenes/scene_loading.h>
 
 #include <zoe_loading_map.h>
+#include <zoe_pipeline_index.h>
 
 #include <metil.h>
+#include <metil_mesh/metil_mesh_2d/metil_mesh_square.h>
+#include <metil_object/metil_object.h>
+#include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_scenes/metil_scene.h>
 
 #include <clic3_bytes.h>
 #include <clic3_memory.h>
+
+#include <math_c_absolute.h>
 
 void scene_loading_initialize(
   struct metil* metil,
@@ -58,8 +64,47 @@ void scene_loading_initialize(
   metil_scene_initialize_with_renderables(
     metil,
     metil_scene_loading,
-    0
+    1
   );
+
+  metil_renderable_initialize_at_index(
+    metil_scene_loading->renderables,
+    0,
+    metil_renderable_type_object
+  );
+
+  struct metil_object* metil_object_loading_screen = (
+    metil_scene_loading->renderables[
+      0
+    ].renderable
+  );
+
+
+  metil_mesh_square_initialize(
+    &metil_object_loading_screen->mesh,
+    2.0f
+  );
+
+  metil_object_loading_screen->positioning = (
+    metil_positioning_absolute
+  );
+
+  metil_object_loading_screen->index_pipeline_render = (
+    zoe_pipeline_index_loading_screen
+  );
+
+  metil_object_buffers_initialize(
+    metil_object_loading_screen,
+    metil->renderer_interface.metal_device
+  );
+
+  struct metil_renderer_data_object* metil_renderer_data_object_loading_screen = (
+    metil_object_loading_screen->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
+  );
+
+  metil_renderer_data_object_loading_screen->noise = 0;
 
   metil_scene_loading->data = (
     data_scene_loading
@@ -85,6 +130,25 @@ void scene_loading_poll(
       data_scene_loading->id_scene,
       &data_scene_loading->data
     )
+  );
+
+  struct metil_object* metil_object_loading_screen = (
+    metil_scene_loading->renderables[
+      0
+    ].renderable
+  );
+
+  struct metil_renderer_data_object* metil_renderer_data_object_loading_screen = (
+    metil_object_loading_screen->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
+  );
+
+  metil_renderer_data_object_loading_screen->noise = (
+    math_c_absolute_float(
+      progress
+    ) *
+    10000.0f
   );
 
   if (

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -1,7 +1,6 @@
 #include <scenes/scene_menu_main.h>
 
 #include <menus/menu_main.h>
-#include <metil_rendering/metil_camera/metil_camera.h>
 #include <object/object_ground.h>
 #include <object/object_tree.h>
 #include <scenes/scene_id.h>
@@ -15,6 +14,7 @@
 #include <metil_menus/metil_menu_input.h>
 #include <metil_object/metil_object_text.h>
 #include <metil_paths/metil_paths.h>
+#include <metil_rendering/metil_camera/metil_camera.h>
 #include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_rendering/metil_renderer_interface.h>
 #include <metil_scenes/metil_scene.h>

--- a/sources/zoe.m
+++ b/sources/zoe.m
@@ -104,6 +104,18 @@ void zoe_renderer_on_initialize(
     ]
   ];
 
+  zoe_pipeline_index_loading_screen = [
+    metil->renderer_interface.renderer
+    pipeline_add: [
+      metil->library.library
+      newFunctionWithName: @"zoe_loading_screen_fragment"
+    ]
+    function_vertex: [
+      metil->library.library
+      newFunctionWithName: @"zoe_loading_screen_vertex"
+    ]
+  ];
+
   zoe_pipeline_index_player_arm = [
     metil->renderer_interface.renderer
     pipeline_add: [

--- a/sources/zoe_loading_threads.m
+++ b/sources/zoe_loading_threads.m
@@ -75,17 +75,31 @@ void zoe_loading_threads_spawn(
     &zoe_loading_threads->data,
     (
       sizeof(
-        struct zoe_loading_threads_data
+        void*
       ) *
       zoe_loading_threads->length
     )
   );
 
-  struct zoe_loading_threads_data* zoe_loading_threads_data = &(
-    zoe_loading_threads->data[
-      zoe_loading_threads->length -
-      1
-    ]
+  static struct zoe_loading_threads_data* zoe_loading_threads_data;
+  
+  zoe_loading_threads_data = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct zoe_loading_threads_data
+      )
+    )
+  );
+
+  zoe_loading_threads->data[
+    zoe_loading_threads->length -
+    1
+  ] = (
+    zoe_loading_threads_data
+  );
+
+  zoe_loading_threads_data->loading_threads = (
+    zoe_loading_threads
   );
 
   zoe_loading_threads_data->metil = (
@@ -209,7 +223,7 @@ void zoe_loading_threads_destroy(
       0
     );
 
-    struct zoe_loading_threads_data* zoe_loading_threads_data = &(
+    struct zoe_loading_threads_data* zoe_loading_threads_data = (
       zoe_loading_threads->data[
         index_thread
       ]
@@ -217,6 +231,10 @@ void zoe_loading_threads_destroy(
 
     clic3_memory_free(
       zoe_loading_threads_data->data
+    );
+
+    clic3_memory_free_raw(
+      zoe_loading_threads_data
     );
   }
 

--- a/sources/zoe_pipeline_index.c
+++ b/sources/zoe_pipeline_index.c
@@ -2,6 +2,7 @@
 
 unsigned short int zoe_pipeline_index_ground = 0;
 unsigned short int zoe_pipeline_index_hill = 0;
+unsigned short int zoe_pipeline_index_loading_screen = 0;
 unsigned short int zoe_pipeline_index_player_arm = 0;
 unsigned short int zoe_pipeline_index_player_body = 0;
 unsigned short int zoe_pipeline_index_player_head = 0;


### PR DESCRIPTION
cuts initialization time down from 940 to 360 or so.


https://github.com/user-attachments/assets/95337d88-aec2-4552-b3f0-723bea893603

also adds in the loading screen visual