### PR TITLE
[enh] Model zoe body torso start

### DIFF
--- a/sources/mesh/mesh_zoe_body.c
+++ b/sources/mesh/mesh_zoe_body.c
@@ -8,8 +8,6 @@
 
 #include <metil_mesh/metil_mesh.h>
 
-#include <stdio.h>
-
 void mesh_zoe_body_initialize(
   struct metil_mesh* metil_mesh_zoe_body
 ) {
@@ -21,14 +19,19 @@ void mesh_zoe_body_initialize(
 
   // leg measurements
 
+  float circumference_ankle = (
+    2.0f
+  );
+
   float diameter_ankle = (
-    1.0f
+    circumference_ankle / 
+    math_c_pi
   );
 
   float length_leg = (
     // height /
     3.0f *
-    diameter_ankle
+    circumference_ankle
   );
 
   float length_calf = (
@@ -47,7 +50,7 @@ void mesh_zoe_body_initialize(
 
   float diameter_calf = (
     diameter_ankle *
-    1.6f
+    1.75f
   );
 
   float radius_calf = (
@@ -65,19 +68,12 @@ void mesh_zoe_body_initialize(
     2.0f
   );
 
-  float gap_thigh = (
-    // diameter_ankle *
-    // 0.25f
-    0.0f
-  );
-
   float diameter_hips = (
     diameter_thigh *
-    2.0f +
-    gap_thigh
+    2.0f
   );
 
-  float radius_hip = (
+  float radius_hips = (
     diameter_hips /
     2.0f
   );
@@ -86,10 +82,25 @@ void mesh_zoe_body_initialize(
     length_calf
   );
 
+  float length_torso = (
+    length_leg *
+    0.75f
+  );
+
+  float length_head = (
+    length_leg *
+    0.25f
+  );
+
   // waist measurements
   float diameter_waist = (
     diameter_hips *
-    0.95f
+    0.90f
+  );
+
+  float radius_waist = (
+    diameter_waist /
+    2.0f
   );
 
   unsigned int length_segments_leg = 40;
@@ -99,16 +110,26 @@ void mesh_zoe_body_initialize(
     length_segments_leg_radial
   );
 
+  unsigned int length_segments_waist = 40;
+  unsigned int length_segments_waist_radial = 40;
+  unsigned int length_vertices_torso = (
+    length_segments_waist *
+    length_segments_waist_radial
+  );
+
   metil_mesh_zoe_body->length_indices = (
     length_vertices_leg *
     // 6 *
     2 * // 2 legs
+    2 +
+    length_vertices_torso *
     2
   );
 
   metil_mesh_zoe_body->length_vertices = (
     length_vertices_leg *
-    2
+    2 +
+    length_vertices_torso
   );
 
   clic3_memory_reallocate_raw(
@@ -131,7 +152,7 @@ void mesh_zoe_body_initialize(
     )
   );
 
-  unsigned int index_vertex = (
+  unsigned long int index_vertex = (
     0
   );
 
@@ -247,7 +268,11 @@ void mesh_zoe_body_initialize(
           (
             radius_calf -
             radius_ankle *
-            0.125f
+            0.125f *
+            (
+              1.0f -
+              percentage_thigh
+            )
           )
         );
 
@@ -307,7 +332,8 @@ void mesh_zoe_body_initialize(
         ) {
           percentage_segment_leg = (
             percentage_segment_leg +
-            0.125f
+            // 0.125f
+            0
           );
         }
 
@@ -359,6 +385,109 @@ void mesh_zoe_body_initialize(
   }
 
   for (
+    unsigned int index_vertex_torso = 0;
+    index_vertex_torso < length_vertices_torso;
+    ++index_vertex_torso
+  ) {
+    unsigned int index_segment_waist = (
+      index_vertex_torso /
+      length_segments_waist_radial
+    );
+
+    unsigned int index_segment_radial_waist = (
+      index_vertex_torso %
+      length_segments_waist_radial
+    );
+
+    float percentage_segment_waist = (
+      (float) index_segment_waist /
+      (float) (
+        length_segments_waist -
+        1
+      )
+    );
+
+    float percentage_segment_radial_waist = (
+      (float) index_segment_radial_waist /
+      (float) (
+        length_segments_waist_radial -
+        1
+      )
+    );
+
+    float asdf = (
+      math_c_sine(
+        (
+          percentage_segment_waist *
+          math_c_pi
+        ),
+        math_c_pi
+      )
+    );
+
+    float radius = (
+      (
+        radius_hips *
+        (
+          1.0f -
+          asdf
+        )
+      ) +
+      (
+        radius_waist *
+        asdf
+      )
+    );
+
+    float angle = (
+      percentage_segment_radial_waist *
+      math_c_pi_doubled
+    );
+
+    metil_mesh_zoe_body->vertices[
+      index_vertex
+    ].x = (
+      math_c_sine(
+        angle,
+        math_c_pi
+      ) *
+      radius
+    );
+
+    metil_mesh_zoe_body->vertices[
+      index_vertex
+    ].y = (
+      length_leg +
+      (
+        percentage_segment_waist *
+        length_torso
+      )
+    );
+
+    metil_mesh_zoe_body->vertices[
+      index_vertex
+    ].z = (
+      math_c_cosine(
+        angle,
+        math_c_pi
+      ) *
+      radius *
+      0.6f
+    );
+
+    metil_mesh_zoe_body->vertices[
+      index_vertex
+    ].w = (
+      1.0f
+    );
+
+    index_vertex = (
+      index_vertex +
+      1
+    );
+  }
+
+  for (
     unsigned int index_indices = 0;
     index_indices < metil_mesh_zoe_body->length_indices;
     ++index_indices
@@ -374,4 +503,6 @@ void mesh_zoe_body_initialize(
       )
     );
   }
+
+
 }

--- a/sources/scenes/scene_intro_hill.m
+++ b/sources/scenes/scene_intro_hill.m
@@ -7,6 +7,7 @@
 #include <group/group_text_with_backing.h>
 #include <input/input_movement.h>
 #include <mesh/mesh_hill.h>
+#include <mesh/mesh_zoe_body.h>
 #include <model/model_player.h>
 #include <model/model_zoe.h>
 #include <object/object_hill.h>
@@ -139,7 +140,7 @@ void scene_intro_hill_initialize(
     ) {
       case scene_intro_hill_index_renderable_player:
       case scene_intro_hill_index_renderable_player_mirror:
-      case scene_intro_hill_index_renderable_zoe:
+      
         metil_renderable_initialize_at_index(
           scene->renderables,
           index_renderable,
@@ -379,15 +380,27 @@ void scene_intro_hill_initialize(
     1
   );
 
-  struct metil_model* metil_model_zoe = (
+  struct metil_object* metil_object_zoe = (
     scene->renderables[
       scene_intro_hill_index_renderable_zoe
     ].renderable
   );
 
-  zoe_model_zoe_initialize(
-    metil,
-    metil_model_zoe
+  mesh_zoe_body_initialize(
+    &metil_object_zoe->mesh
+  );
+
+  metil_object_zoe->type_primitive = (
+    MTLPrimitiveTypeLineStrip
+  );
+
+  metil_object_zoe->index_pipeline_render = (
+    zoe_pipeline_index_zoe_body
+  );
+
+  metil_object_buffers_initialize(
+    metil_object_zoe,
+    metil->renderer_interface.metal_device
   );
 
   struct metil_object* metil_object_hill = (


### PR DESCRIPTION
- start on torso
- use circumference instead of diameter for base measurement
- fix a bit of thigh radius

changing this to an object for now because `metil_modal` segfaults with vertex counts over 4090 or so, idk why i'll look into it later. not a gpu limitation as i rendered a tree with over 100000000 vertices (not counting the branches, just the trunk)

<img width="613" height="982" alt="Screenshot 2026-02-09 at 21 59 35" src="https://github.com/user-attachments/assets/14afb0a1-cb78-4ba4-9c33-011d909df68a" />
<img width="1018" height="649" alt="Screenshot 2026-02-09 at 21 59 46" src="https://github.com/user-attachments/assets/3856a563-35b8-4014-9808-3421e2f55d1b" />

i feel like a stick