### PR TITLE
[dev] Zoe inventory

### DIFF
--- a/include/data/data_player.h
+++ b/include/data/data_player.h
@@ -1,7 +1,9 @@
 #ifndef __zoe_data_data_player_h
 #define __zoe_data_data_player_h
 
+#include <inventory/zoe_inventory.h>
 #include <items/zoe_item.h>
+#include <weapons/zoe_weapon.h>
 
 enum zoe_data_player_action {
   zoe_data_player_action_none   = 0b00000000,
@@ -20,8 +22,13 @@ struct zoe_data_player {
   unsigned char actions;
   unsigned char attributes;
 
+  struct zoe_weapon* weapon_primary;
+  struct zoe_weapon* weapon_secondary;
+
   struct zoe_item* item_primary;
   struct zoe_item* item_secondary;
+
+  struct zoe_inventory inventory;
 };
 
 void zoe_data_player_initialize(

--- a/include/inventory/zoe_inventory.h
+++ b/include/inventory/zoe_inventory.h
@@ -1,0 +1,14 @@
+#ifndef __zoe_inventory_zoe_inventory_h
+#define __zoe_inventory_zoe_inventory_h
+
+#include <inventory/zoe_inventory_item.h>
+
+struct zoe_inventory {
+  unsigned char length_items;
+  unsigned char length_maximum_items;
+
+  struct zoe_inventory_item* items;
+};
+
+#endif
+

--- a/include/inventory/zoe_inventory_item.h
+++ b/include/inventory/zoe_inventory_item.h
@@ -1,0 +1,16 @@
+#ifndef __zoe_inventory_zoe_inventory_item_h
+#define __zoe_inventory_zoe_inventory_item_h
+
+enum zoe_inventory_item_type {
+  zoe_inventory_item_type_item   = 0x00,
+  zoe_inventory_item_type_weapon = 0x01
+};
+
+struct zoe_inventory_item {
+  enum zoe_inventory_item_type type;
+
+  void* item;
+}
+
+#endif
+

--- a/include/inventory/zoe_inventory_item.h
+++ b/include/inventory/zoe_inventory_item.h
@@ -10,7 +10,7 @@ struct zoe_inventory_item {
   enum zoe_inventory_item_type type;
 
   void* item;
-}
+};
 
 #endif
 


### PR DESCRIPTION
- `zoe_inventory_item`:add
- `zoe_inventory`:add
- `data_player`:add->{`inventory`};


ill probably restructure this a bit more

the primary and secondary weapons need to point to inventory items. i could just change those pointers to be to `struct zoe_inventory_item`, will decide later on.

as for the item within inventory item itself that will likely be allocated data rather than a pointer to a specific item, though it could be either. if i make it into a pointer than i can just have constant items that get defined and then the items can just point to those, however, i could also allocate specific space for items and then items can have more individual properties attached to them. a few ways to set this up.