### PR TITLE
[dev] [`zoe_item`|`zoe_weapon`]:add->{`id`};

### DIFF
--- a/include/items/zoe_item.h
+++ b/include/items/zoe_item.h
@@ -8,6 +8,8 @@ enum zoe_item_type {
 };
 
 struct zoe_item {
+  unsigned short int id;
+
   enum zoe_item_type type;
 };
 

--- a/include/weapons/zoe_weapon.h
+++ b/include/weapons/zoe_weapon.h
@@ -22,6 +22,8 @@ enum zoe_weapon_durability_type {
 };
 
 struct zoe_weapon {
+  unsigned short int id;
+
   enum zoe_weapon_handedness handedness;
   enum zoe_weapon_type type;
   enum zoe_weapon_durability_type durability_type;


### PR DESCRIPTION
- [`zoe_item`|`zoe_weapon`:add->{`id`};
- - will be used for storing references to items and weapons