### PR TITLE
[dev] `zoe_damage`:add

### DIFF
--- a/include/damage/zoe_damage.h
+++ b/include/damage/zoe_damage.h
@@ -1,0 +1,26 @@
+#ifndef __zoe_damage_zoe_damage_h
+#define __zoe_damage_zoe_damage_h
+
+#include <damage/zoe_damage_type.h>
+
+struct zoe_damage {
+  unsigned int amount_primary;
+  unsigned char type_primary;
+
+  unsigned int amount_secondary;
+  unsigned char type_secondary;
+};
+
+void zoe_damage_initialize(
+  struct zoe_damage*
+);
+
+void zoe_damage_initialize_with_attributes(
+  struct zoe_damage*,
+  unsigned int,
+  unsigned char,
+  unsigned int,
+  unsigned char
+);
+
+#endif

--- a/include/damage/zoe_damage_type.h
+++ b/include/damage/zoe_damage_type.h
@@ -1,0 +1,7 @@
+#ifndef __zoe_damage_zoe_damage_type_h
+#define __zoe_damage_zoe_damage_type_h
+
+#define zoe_damage_type_none  0b00000000
+#define zoe_damage_type_basic 0b00000001
+
+#endif

--- a/sources/damage/zoe_damage.c
+++ b/sources/damage/zoe_damage.c
@@ -1,0 +1,37 @@
+#include <damage/zoe_damage.h>
+
+void zoe_damage_initialize(
+  struct zoe_damage* zoe_damage
+) {
+  zoe_damage_initialize_with_attributes(
+    zoe_damage,
+    0x00,
+    zoe_damage_type_basic,
+    0x00,
+    zoe_damage_type_none
+  );
+}
+
+void zoe_damage_initialize_with_attributes(
+  struct zoe_damage* zoe_damage,
+  unsigned int amount_primary,
+  unsigned char type_primary,
+  unsigned int amount_secondary,
+  unsigned char type_secondary
+) {
+  zoe_damage->amount_primary = (
+    amount_primary
+  );
+
+  zoe_damage->type_primary = (
+    type_primary
+  );
+
+  zoe_damage->amount_secondary = (
+    amount_secondary
+  );
+
+  zoe_damage->type_secondary = (
+    type_secondary
+  );
+}


### PR DESCRIPTION
will be used to apply damage towards enemies and towards zoe

damage structure will be passed to a `damage` function which then determines the actual damage based upon the damage structure properties

damage types are bit flags in order to combine damage types as a singular thing

for example if i set `fire` to 0b0010 and `ice` to `0b0100` then have a damage structure with the type of `0b0110` then it will be icefire damage rather than just fire or ice.