### PR TITLE
[dev|enh] Zoe enemies initial generation

### DIFF
--- a/include/enemies/zoe_enemy.h
+++ b/include/enemies/zoe_enemy.h
@@ -3,6 +3,8 @@
 
 #include <damage/zoe_damage.h>
 
+#include <math_c_vector.h>
+
 #include <metil.h>
 #include <metil_rendering/metil_renderable.h>
 
@@ -32,6 +34,9 @@ struct zoe_enemy {
   unsigned short int health_maximum;
 
   struct metil_renderable* _Nonnull renderable;
+
+  struct math_c_vector3_float* _Nonnull position;
+  struct math_c_vector3_float* _Nonnull rotation;
 
   zoe_enemy_function_poll _Nonnull poll;
   zoe_enemy_function_damage _Nonnull damage;

--- a/include/enemies/zoe_enemy.h
+++ b/include/enemies/zoe_enemy.h
@@ -7,6 +7,7 @@
 
 #include <metil.h>
 #include <metil_rendering/metil_renderable.h>
+#include <metil_scenes/metil_scene.h>
 
 #define zoe_enemy_default_health_maximum 5
 #define zoe_enemy_default_health zoe_enemy_default_health_maximum
@@ -15,6 +16,7 @@ struct zoe_enemy;
 
 typedef void (*zoe_enemy_function_poll)(
   struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
   struct zoe_enemy* _Nonnull
 );
 
@@ -53,6 +55,7 @@ void zoe_enemy_initialize(
 
 void zoe_enemy_poll(
   struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
   struct zoe_enemy* _Nonnull
 );
 
@@ -69,6 +72,7 @@ void zoe_enemy_destroy(
 
 void zoe_enemy_default_poll(
   struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
   struct zoe_enemy* _Nonnull
 );
 

--- a/include/enemies/zoe_enemy_auop.h
+++ b/include/enemies/zoe_enemy_auop.h
@@ -5,6 +5,7 @@
 
 #include <metil.h>
 #include <metil_rendering/metil_renderable.h>
+#include <metil_scenes/metil_scene.h>
 
 #define zoe_enemy_auop_default_health_maximum 0x05
 #define zoe_enemy_auop_default_health zoe_enemy_auop_default_health_maximum
@@ -13,6 +14,12 @@ void zoe_enemy_auop_initialize(
   struct metil* _Nonnull,
   struct zoe_enemy* _Nonnull,
   struct metil_renderable* _Nonnull
+);
+
+void zoe_enemy_auop_poll(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  struct zoe_enemy* _Nonnull
 );
 
 #endif

--- a/include/enemies/zoe_enemy_controller.h
+++ b/include/enemies/zoe_enemy_controller.h
@@ -6,6 +6,7 @@
 
 #include <metil.h>
 #include <metil_group.h>
+#include <metil_scenes/metil_scene.h>
 
 struct zoe_enemy_controller {
   struct metil_group* _Nonnull group_enemies;
@@ -43,6 +44,12 @@ void zoe_enemy_controller_damage_at_index(
   struct zoe_enemy_controller* _Nonnull,
   struct zoe_damage* _Nonnull,
   unsigned int
+);
+
+void zoe_enemy_controller_poll(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  struct zoe_enemy_controller* _Nonnull
 );
 
 void zoe_enemy_controller_destroy(

--- a/include/scenes/scene_intro_forest/scene_intro_forest.h
+++ b/include/scenes/scene_intro_forest/scene_intro_forest.h
@@ -2,6 +2,7 @@
 #define __zoe_scenes_scene_intro_forest_scene_intro_forest_h
 
 #include <audio/io_proc_data.h>
+#include <enemies/zoe_enemy_controller.h>
 #include <zoe_loading_threads.h>
 
 #include <metil_group.h>
@@ -15,17 +16,18 @@
 #endif
 #include <MetalKit/MetalKit.h>
 
-#define scene_intro_forest_length_renderables 0x07
+#define scene_intro_forest_length_renderables 0x08
 #define scene_intro_forest_length_group_trees_renderables 1000
 
 enum scene_intro_forest_index_renderable {
   scene_intro_forest_index_renderable_ground           = 0x00,
   scene_intro_forest_index_renderable_player           = 0x01,
   scene_intro_forest_index_renderable_player_mirror    = 0x02,
-  scene_intro_forest_index_renderable_group_trees      = 0x03,
-  scene_intro_forest_index_renderable_group_text_place = 0x04,
-  scene_intro_forest_index_renderable_group_text_used  = 0x05,
-  scene_intro_forest_index_renderable_group_text_this  = 0x06
+  scene_intro_forest_index_renderable_group_enemies    = 0x03,
+  scene_intro_forest_index_renderable_group_trees      = 0x04,
+  scene_intro_forest_index_renderable_group_text_place = 0x05,
+  scene_intro_forest_index_renderable_group_text_used  = 0x06,
+  scene_intro_forest_index_renderable_group_text_this  = 0x07
 };
 
 enum textures_scene_intro_forest {
@@ -36,6 +38,8 @@ enum textures_scene_intro_forest {
 
 struct scene_intro_forest_data {
   struct io_proc_data* _Nonnull io_proc_data;
+
+  struct zoe_enemy_controller enemy_controller;
 
   unsigned char index_text;
 };

--- a/sources/enemies/zoe_enemy.m
+++ b/sources/enemies/zoe_enemy.m
@@ -115,16 +115,6 @@ void zoe_enemy_default_destroy(
   struct metil* metil,
   struct zoe_enemy* zoe_enemy
 ) {
-  if (
-    zoe_enemy->renderable !=
-    0x00
-  ) {
-    metil_renderable_destroy(
-      metil,
-      zoe_enemy->renderable
-    );
-  }
-
   clic3_memory_free(
     zoe_enemy->data
   );

--- a/sources/enemies/zoe_enemy.m
+++ b/sources/enemies/zoe_enemy.m
@@ -6,6 +6,7 @@
 
 #include <metil.h>
 #include <metil_rendering/metil_renderable.h>
+#include <metil_scenes/metil_scene.h>
 
 void zoe_enemy_initialize(
   struct metil* metil,
@@ -43,10 +44,12 @@ void zoe_enemy_initialize(
 
 void zoe_enemy_poll(
   struct metil* metil,
+  struct metil_scene* metil_scene,
   struct zoe_enemy* zoe_enemy
 ) {
   zoe_enemy->poll(
     metil,
+    metil_scene,
     zoe_enemy
   );
 }
@@ -75,6 +78,7 @@ void zoe_enemy_destroy(
 
 void zoe_enemy_default_poll(
   struct metil* metil,
+  struct metil_scene* metil_scene,
   struct zoe_enemy* zoe_enemy
 ) {
 }

--- a/sources/enemies/zoe_enemy_auop.m
+++ b/sources/enemies/zoe_enemy_auop.m
@@ -2,9 +2,14 @@
 
 #include <enemies/zoe_enemy.h>
 
+#include <math_c_vector.h>
+
 #include <metil_mesh/metil_mesh_box.h>
 #include <metil_object/metil_object.h>
+#include <metil_player/metil_player.h>
 #include <metil_rendering/metil_renderable.h>
+#include <metil_scenes/metil_scene.h>
+#include <metil_scenes/metil_scene_controller.h>
 
 void zoe_enemy_auop_initialize(
   struct metil* metil,
@@ -41,7 +46,7 @@ void zoe_enemy_auop_initialize(
         0x04
       ),
       .y = (
-        0x04
+        0x08
       ),
       .z = (
         0x04
@@ -61,4 +66,37 @@ void zoe_enemy_auop_initialize(
   zoe_enemy_auop->rotation = &(
     zoe_enemy_object->rotation
   );
+
+  zoe_enemy_auop->poll = (
+    zoe_enemy_auop_poll
+  );
 }
+
+void zoe_enemy_auop_poll(
+  struct metil* metil,
+  struct metil_scene* metil_scene,
+  struct zoe_enemy* zoe_enemy_auop
+) {
+  zoe_enemy_auop->position->x = (
+    zoe_enemy_auop->position->x +
+    (
+      (
+        zoe_enemy_auop->position->x >
+        metil_scene->player.position.x
+      )
+      ? -0x01
+      :  0x01
+    )
+  );
+
+  zoe_enemy_auop->position->z = (
+    zoe_enemy_auop->position->z +
+    (
+      (
+        zoe_enemy_auop->position->z >
+        metil_scene->player.position.z
+      )
+      ? -0x01
+      :  0x01
+    )
+  );  }

--- a/sources/enemies/zoe_enemy_auop.m
+++ b/sources/enemies/zoe_enemy_auop.m
@@ -94,7 +94,8 @@ void zoe_enemy_auop_poll(
       ? -0x01
       :  0x01
     ) *
-    amount  );
+    amount
+  );
 
   zoe_enemy_auop->position->z = (
     zoe_enemy_auop->position->z +

--- a/sources/enemies/zoe_enemy_auop.m
+++ b/sources/enemies/zoe_enemy_auop.m
@@ -53,4 +53,12 @@ void zoe_enemy_auop_initialize(
     zoe_enemy_object,
     metil->renderer_interface.metal_device
   );
+
+  zoe_enemy_auop->position = &(
+    zoe_enemy_object->position
+  );
+
+  zoe_enemy_auop->rotation = &(
+    zoe_enemy_object->rotation
+  );
 }

--- a/sources/enemies/zoe_enemy_auop.m
+++ b/sources/enemies/zoe_enemy_auop.m
@@ -77,8 +77,15 @@ void zoe_enemy_auop_poll(
   struct metil_scene* metil_scene,
   struct zoe_enemy* zoe_enemy_auop
 ) {
+  float amount = (
+    (float)
+    metil_scene->time_delta *
+    0.01f
+  );
+
   zoe_enemy_auop->position->x = (
     zoe_enemy_auop->position->x +
+    (float)
     (
       (
         zoe_enemy_auop->position->x >
@@ -86,11 +93,12 @@ void zoe_enemy_auop_poll(
       )
       ? -0x01
       :  0x01
-    )
-  );
+    ) *
+    amount  );
 
   zoe_enemy_auop->position->z = (
     zoe_enemy_auop->position->z +
+    (float)
     (
       (
         zoe_enemy_auop->position->z >
@@ -98,6 +106,7 @@ void zoe_enemy_auop_poll(
       )
       ? -0x01
       :  0x01
-    )
+    ) *
+    amount
   );
 }

--- a/sources/enemies/zoe_enemy_auop.m
+++ b/sources/enemies/zoe_enemy_auop.m
@@ -99,4 +99,5 @@ void zoe_enemy_auop_poll(
       ? -0x01
       :  0x01
     )
-  );  }
+  );
+}

--- a/sources/enemies/zoe_enemy_controller.m
+++ b/sources/enemies/zoe_enemy_controller.m
@@ -291,13 +291,12 @@ void zoe_enemy_controller_poll(
         zoe_enemy_controller,
         index_enemy
       );
-    }
-else {
-      index_enemy = (
+    } else {      index_enemy = (
         index_enemy +
         0x01
       );
-    }  }
+    }
+  }
 }
 
 void zoe_enemy_controller_destroy(

--- a/sources/enemies/zoe_enemy_controller.m
+++ b/sources/enemies/zoe_enemy_controller.m
@@ -2,7 +2,9 @@
 
 #include <clic3_memory.h>
 
+#include <metil.h>
 #include <metil_group.h>
+#include <metil_scenes/metil_scene.h>
 
 void zoe_enemy_controller_initialize(
   struct metil* metil,
@@ -252,6 +254,50 @@ void zoe_enemy_controller_damage_at_index(
       index_enemy
     );
   }
+}
+
+void zoe_enemy_controller_poll(
+  struct metil* metil,
+  struct metil_scene* metil_scene,
+  struct zoe_enemy_controller* zoe_enemy_controller
+) {
+  for (
+    unsigned int index_enemy = (
+      0x00
+    );
+    (
+      index_enemy <
+      *zoe_enemy_controller->length_enemies
+    );
+  ) {
+    struct zoe_enemy* zoe_enemy = (
+      zoe_enemy_controller->enemies[
+        index_enemy
+      ]
+    );
+
+    zoe_enemy_poll(
+      metil,
+      metil_scene,
+      zoe_enemy
+    );
+
+    if (
+      zoe_enemy->health ==
+      0x00
+    ) {
+      zoe_enemy_controller_enemy_remove_at_index(
+        metil,
+        zoe_enemy_controller,
+        index_enemy
+      );
+    }
+else {
+      index_enemy = (
+        index_enemy +
+        0x01
+      );
+    }  }
 }
 
 void zoe_enemy_controller_destroy(

--- a/sources/scenes/scene_intro_forest/scene_intro_forest.m
+++ b/sources/scenes/scene_intro_forest/scene_intro_forest.m
@@ -2,6 +2,8 @@
 
 #include <audio/io_proc_data.h>
 #include <data/data_zoe.h>
+#include <enemies/zoe_enemy_auop.h>
+#include <enemies/zoe_enemy_controller.h>
 #include <group/group_text_with_backing.h>
 #include <input/input_movement.h>
 #include <model/model_zoe.h>
@@ -185,6 +187,7 @@ void scene_intro_forest_initialize(
         );
         break;
       }
+      case scene_intro_forest_index_renderable_group_enemies:
       case scene_intro_forest_index_renderable_group_trees: {
         metil_renderable_initialize_at_index(
           scene->renderables,
@@ -257,6 +260,14 @@ void scene_intro_forest_initialize(
       }
     }
   }
+
+  zoe_enemy_controller_initialize(
+    metil,
+    &data_scene->enemy_controller,
+    scene->renderables[
+      scene_intro_forest_index_renderable_group_enemies
+    ].renderable
+  );
 
   scene->length_textures = 3;
   scene->textures = realloc(
@@ -680,15 +691,100 @@ void zoe_scene_intro_forest_threaded_trees_initialization(
 
 void scene_intro_forest_poll(
   struct metil* metil,
-  struct metil_scene* scene
+  struct metil_scene* metil_scene
 ) {
   metil_scene_poll_default(
     metil,
-    scene
+    metil_scene
   );
 
+  struct scene_intro_forest_data* scene_intro_forest_data = (
+    metil_scene->data
+  );
+
+  struct zoe_enemy_controller* zoe_enemy_controller = &(
+    scene_intro_forest_data->enemy_controller
+  );
+
+  zoe_enemy_controller_poll(
+    metil,
+    metil_scene,
+    zoe_enemy_controller
+  );
+
+  if (
+    (
+      *zoe_enemy_controller->length_enemies <
+      (
+        metil_scene->time_elapsed /
+        0x03e8
+      )
+    ) &&
+    (
+      *zoe_enemy_controller->length_enemies <
+      0x64
+    )
+  ) {
+    zoe_enemy_controller_enemies_add_length(
+      metil,
+      zoe_enemy_controller,
+      0x01
+    );
+
+    unsigned int index_enemy = (
+      *zoe_enemy_controller->length_enemies -
+      0x01
+    );
+
+    struct metil_renderable* metil_renderable_enemy = (
+      zoe_enemy_controller->group_enemies->renderables[
+        index_enemy
+      ]
+    );
+
+    struct zoe_enemy* zoe_enemy_auop = (
+      zoe_enemy_controller->enemies[
+        index_enemy
+      ]
+    );
+
+    zoe_enemy_auop_initialize(
+      metil,
+      zoe_enemy_auop,
+      metil_renderable_enemy
+    );
+
+    zoe_enemy_auop->position->x = (
+      metil_scene->player.position.x +
+      (
+        metil_scene->time_elapsed %
+        0x20
+      )
+    );
+
+    zoe_enemy_auop->position->z = (
+      metil_scene->player.position.z +
+      (
+        (
+          metil_scene->time_elapsed +
+          0x45
+        ) %
+        0x20
+      ) *
+      (
+        (
+          metil_scene->time_delta %
+          0x02
+        ) ==
+        0x00
+        ? -0x01
+        :  0x01
+      )
+    );
+  }
+
   struct metil_group* metil_group_trees = (
-    scene->renderables[
+    metil_scene->renderables[
       scene_intro_forest_index_renderable_group_trees
     ].renderable
   );
@@ -706,37 +802,37 @@ void scene_intro_forest_poll(
 
     metil_collision_player_object_uncollide_circular_xz(
       metil_object_tree,
-      &scene->player
+      &metil_scene->player
     );
   }
 
   struct metil_group* metil_group_text_place = (
-    scene->renderables[
+    metil_scene->renderables[
       scene_intro_forest_index_renderable_group_text_place
     ].renderable
   );
 
   struct metil_group* metil_group_text_used = (
-    scene->renderables[
+    metil_scene->renderables[
       scene_intro_forest_index_renderable_group_text_used
     ].renderable
   );
 
   struct metil_group* metil_group_text_this = (
-    scene->renderables[
+    metil_scene->renderables[
       scene_intro_forest_index_renderable_group_text_this
     ].renderable
   );
 
   if (
-    scene->time_elapsed <
+    metil_scene->time_elapsed <
     6000
   ) {
     metil_group_text_place->visible = (
       0x01
     );
   } else if (
-    scene->time_elapsed <
+    metil_scene->time_elapsed <
     12000
   ) {
     metil_group_text_place->visible = (
@@ -747,7 +843,7 @@ void scene_intro_forest_poll(
       0x01
     );
   } else if (
-    scene->time_elapsed <
+    metil_scene->time_elapsed <
     24000
   ) {
     metil_group_text_place->visible = (
@@ -782,6 +878,11 @@ void scene_intro_forest_destroy(
 ) {
   struct scene_intro_forest_data* scene_intro_forest_data = (
     metil_scene->data
+  );
+
+  zoe_enemy_controller_destroy(
+    metil,
+    &scene_intro_forest_data->enemy_controller
   );
 
   struct io_proc_data* io_proc_data = (

--- a/sources/scenes/scene_intro_forest/scene_intro_forest_loading.m
+++ b/sources/scenes/scene_intro_forest/scene_intro_forest_loading.m
@@ -35,10 +35,12 @@ unsigned char zoe_scene_intro_forest_loading_initialize_function(
   zoe_loading_threads_spawn(
     zoe_loading_threads,
     scene_intro_forest_initialize,
-    0
+    0x00
   );
 
-  return 0;
+  return (
+    0x00
+  );
 }
 
 float zoe_scene_intro_forest_loading_poll_function(

--- a/sources/zoe_loading_map.m
+++ b/sources/zoe_loading_map.m
@@ -116,7 +116,9 @@ unsigned char zoe_scene_loading_loading_initialize_function_no_load(
       break;
   }
 
-  return 1;
+  return (
+    0x01
+  );
 }
 
 float zoe_scene_loading_loading_poll_function_no_load(
@@ -125,7 +127,9 @@ float zoe_scene_loading_loading_poll_function_no_load(
   unsigned char id_scene,
   void** data
 ) {
-  return 1.0f;
+  return (
+    0x01
+  );
 }
 
 void zoe_scene_loading_loading_finished_function_no_load(
@@ -133,4 +137,5 @@ void zoe_scene_loading_loading_finished_function_no_load(
   struct metil_scene* metil_scene,
   unsigned char id_scene,
   void** data
-) {}
+) {
+}


### PR DESCRIPTION
- `zoe_enemy`
- - add position and rotation pointers
- - - allows checking/updating position/rotation without needing to know the renderable type
- - add `metil_scene` to polling
- - - prevents needing to go through `metil` and `metil_scene_controller` to get the `metil_scene`
- - - may add in more data objects later, technically everything is accessible via `metil` but yeah
- - dont destroy renderable by default
- - - this is left up to the controller or scene
- - - - if controller removes an enemy the renderable is destroyed there
- - - - if the scene is destroyed then the renderables are destroyed in the default scene destroy renderable destroy group destroy function calls
- `zoe_enemy_controller`
- - add polling
- - - polls each enemy, checks after polling if health is at `0x00` and removes them if so
- `zoe_scene_intro_forest`
- - add initial enemy controller and enemy generation/population

https://github.com/user-attachments/assets/602f7f7a-d405-4cce-9017-3c44f6eec8f0

