### PR TITLE
[bug] `zoe_data_metal_player`:fix_division_by_zero

### DIFF
--- a/sources/zoe_data/zoe_data_metal_player.c
+++ b/sources/zoe_data/zoe_data_metal_player.c
@@ -12,11 +12,11 @@ void zoe_data_metal_player_initialize(
   );
 
   zoe_data_metal_player->health = (
-    0x00
+    0x01
   );
 
   zoe_data_metal_player->health_maximum = (
-    0x00
+    0x01
   );
 
   zoe_data_metal_player->time_damaged = (


### PR DESCRIPTION
- `zoe_data_metal_player`:fix_division_by_zero
- - the division by zero was causing the statue models to be blue
- - now they are the colour they are supposed to be.